### PR TITLE
fix wrong issuer (audience) in getPostURL

### DIFF
--- a/lib/samlp.js
+++ b/lib/samlp.js
@@ -211,19 +211,20 @@ module.exports.auth = function(options) {
 
   return function (req, res, next) {
     getSamlRequest(req.query.SAMLRequest || req.body.SAMLRequest, function(err, samlRequestDom) {
+      var audience = options.audience;
       if (samlRequestDom) {
         var issuer = xpath.select("//*[local-name(.)='Issuer' and namespace-uri(.)='urn:oasis:names:tc:SAML:2.0:assertion']/text()", samlRequestDom);
-        if (issuer && issuer.length > 0) options.audience = options.audience || issuer[0].textContent;
+        if (issuer && issuer.length > 0) audience = issuer[0].textContent || audience;
 
         var id = samlRequestDom.documentElement.getAttribute('ID');
         if (id) options.inResponseTo = options.inResponseTo || id;
       }
 
-      options.getPostURL(options.audience, samlRequestDom, req, function (err, postUrl) {
+      options.getPostURL(audience, samlRequestDom, req, function (err, postUrl) {
         if (err) { return res.send(500, err); }
         if (!postUrl) { return res.send(401); }
 
-        execute(postUrl, options.audience, req, res, next);
+        execute(postUrl, audience, req, res, next);
       });
     });
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "samlp",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "SAML Protocol server middleware",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
This patch fix an issue when module is used with to service provider.
The first one lock issuer passed to getPostURL function in option as a singleton.
The second one get the first issuer in first parameter