### PR TITLE
Handle case where invalid SAMLRequest is submitted

### DIFF
--- a/lib/samlp.js
+++ b/lib/samlp.js
@@ -15,12 +15,14 @@ function getSamlRequest(samlRequest, callback) {
   if (input[0] === 60) {  // open tag
     // content is just encoded, not zipped
     var xml = new xmldom.DOMParser().parseFromString(input.toString());
+    if (!xml) return callback(new Error('Invalid SAML Request'));
     callback(null, xml);
   } else {
     zlib.inflateRaw(input, function(err, buffer) {
       if (err) return callback(err);
 
       var xml = new xmldom.DOMParser().parseFromString(buffer.toString());
+      if (!xml) new Error('Invalid SAML Request')
       callback(null, xml);
     });
   }
@@ -237,8 +239,6 @@ module.exports.parseRequest = function(req, callback) {
   getSamlRequest(samlRequest, function(err, samlRequestDom) {
     if (err) return callback(err);
 
-    if (!samlRequestDom) return callback(new Error('Invalid SAML Request'));
-    
     var data = {};
     var issuer = xpath.select("//*[local-name(.)='Issuer' and namespace-uri(.)='urn:oasis:names:tc:SAML:2.0:assertion']/text()", samlRequestDom);
     if (issuer && issuer.length > 0) data.issuer = issuer[0].textContent;

--- a/lib/samlp.js
+++ b/lib/samlp.js
@@ -237,6 +237,8 @@ module.exports.parseRequest = function(req, callback) {
   getSamlRequest(samlRequest, function(err, samlRequestDom) {
     if (err) return callback(err);
 
+    if (!samlRequestDom) return callback(new Error('Invalid SAML Request'));
+    
     var data = {};
     var issuer = xpath.select("//*[local-name(.)='Issuer' and namespace-uri(.)='urn:oasis:names:tc:SAML:2.0:assertion']/text()", samlRequestDom);
     if (issuer && issuer.length > 0) data.issuer = issuer[0].textContent;


### PR DESCRIPTION
If an invalid SAMLRequest is submitted, the server would not return a response. Now there is a check to see if xmldom.DOMParser returned undefined.