### PR TITLE
Add issuer/signature sequence test

### DIFF
--- a/test/samlp.signedresponse.tests.js
+++ b/test/samlp.signedresponse.tests.js
@@ -35,7 +35,6 @@ describe('samlp signed response', function () {
     });
 
     it('should contain a valid signed response', function(){
-      console.log(signedResponse);
       var isValid = xmlhelper.verifySignature(
                 signedResponse,
                 server.credentials.cert);

--- a/test/samlp.signedresponse.tests.js
+++ b/test/samlp.signedresponse.tests.js
@@ -3,6 +3,7 @@ var server = require('./fixture/server');
 var request = require('request');
 var cheerio = require('cheerio');
 var xmlhelper = require('./xmlhelper');
+var xmldom = require('xmldom');
 
 describe('samlp signed response', function () {
   before(function (done) {
@@ -56,5 +57,12 @@ describe('samlp signed response', function () {
       expect(destination).to.equal('http://destination');
     });
 
+    it('should have signature after issuer', function(){
+      var doc = new xmldom.DOMParser().parseFromString(signedResponse);
+
+      var signature = doc.documentElement.getElementsByTagName('Signature');
+
+      expect(signature[0].previousSibling.nodeName).to.equal('saml:Issuer');
+    });
   });
 });

--- a/test/samlp.tests.js
+++ b/test/samlp.tests.js
@@ -58,7 +58,7 @@ describe('samlp', function () {
     
       var signature = doc.documentElement.getElementsByTagName('Signature');
 
-      expect('saml:Issuer', signature[0].previousSibling.nodeName);
+      expect(signature[0].previousSibling.nodeName).to.equal('saml:Issuer');
     });
 
     it('should use sha256 as default signature algorithm', function(){


### PR DESCRIPTION
The assertion signature/issuer sequence was being tested, but the response signature/issuer sequence wasn't. This PR adds a test that is failing because it is being added at the bottom of the SAMLResponse. 

I looked into fixing and it seems a little difficult to do because the issuer tag is added here in node-samlp, but the assertion is generate in node-saml.

Any thoughts on this issue? Thanks!