### PR TITLE
fix wrong issuer (audience) in getPostURL

### DIFF
--- a/lib/samlp.js
+++ b/lib/samlp.js
@@ -207,8 +207,6 @@ module.exports.auth = function(options) {
     var user = options.getUserFromRequest(req);
     if (!user) return res.send(401);
 
-    options.audience = options.audience || audience;
-
     getSamlResponse(options, user, function (err, SAMLResponse) {
       if (err) return next(err);
 
@@ -225,19 +223,20 @@ module.exports.auth = function(options) {
 
   return function (req, res, next) {
     getSamlRequest(req.query.SAMLRequest || req.body.SAMLRequest, function(err, samlRequestDom) {
+      var audience = options.audience;
       if (samlRequestDom) {
         var issuer = xpath.select("//*[local-name(.)='Issuer' and namespace-uri(.)='urn:oasis:names:tc:SAML:2.0:assertion']/text()", samlRequestDom);
-        if (issuer && issuer.length > 0) options.audience = options.audience || issuer[0].textContent;
+        if (issuer && issuer.length > 0) audience = audience || issuer[0].textContent;
 
         var id = samlRequestDom.documentElement.getAttribute('ID');
         if (id) options.inResponseTo = options.inResponseTo || id;
       }
 
-      options.getPostURL(options.audience, samlRequestDom, req, function (err, postUrl) {
+      options.getPostURL(audience, samlRequestDom, req, function (err, postUrl) {
         if (err) { return res.send(500, err); }
         if (!postUrl) { return res.send(401); }
 
-        execute(postUrl, options.audience, req, res, next);
+        execute(postUrl, audience, req, res, next);
       });
     });
   };


### PR DESCRIPTION
Rebased PR

This patch fix an issue when module is used with 2 service providers.
The first one lock issuer passed to getPostURL function in option as a singleton.
The second one get the first issuer in first parameter

If you don't set options.audience
You store it in options.audience which is global 
https://github.com/auth0/node-samlp/blob/master/lib/samlp.js#L230
Next time options.audience is setted by previous value
https://github.com/auth0/node-samlp/blob/master/lib/samlp.js#L210
So issuer[0].textContent is never called again
https://github.com/auth0/node-samlp/blob/master/lib/samlp.js#L230