### PR TITLE
Feature - custom response handler support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Options
 | digestAlgorithm     | digest algorithm, options: sha1, sha256          | ```'sha256'``` |
 | RelayState          | state of the auth process                        | ```req.query.RelayState || req.body.RelayState``` |
 | sessionIndex          | the index of a particular session between the principal identified by the subject and the authenticating authority                        | _SessionIndex is not included_ |
-| responseSender | custom sender for SAML response f(req, res, SAMLResponse) | HTML response that POSTS to postUrl |
+| responseHandler       | custom response handler for SAML response f(req, res, SAMLResponse) | HTML response that POSTS to postUrl |
 
 
 Add the middleware as follows:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Options
 | digestAlgorithm     | digest algorithm, options: sha1, sha256          | ```'sha256'``` |
 | RelayState          | state of the auth process                        | ```req.query.RelayState || req.body.RelayState``` |
 | sessionIndex          | the index of a particular session between the principal identified by the subject and the authenticating authority                        | _SessionIndex is not included_ |
-| responseSender        | custom response sender; signature: fn(req,res,samlresponse)| HTML response that POSTS to returnUrl |
+| responseSender | custom sender for SAML response f(req, res, SAMLResponse) | HTML response that POSTS to postUrl |
 
 
 Add the middleware as follows:

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Options
 | digestAlgorithm     | digest algorithm, options: sha1, sha256          | ```'sha256'``` |
 | RelayState          | state of the auth process                        | ```req.query.RelayState || req.body.RelayState``` |
 | sessionIndex          | the index of a particular session between the principal identified by the subject and the authenticating authority                        | _SessionIndex is not included_ |
+| responseSender        | custom response sender; signature: fn(req,res,samlresponse)| HTML response that POSTS to returnUrl |
 
 
 Add the middleware as follows:

--- a/lib/samlp.js
+++ b/lib/samlp.js
@@ -215,12 +215,16 @@ module.exports.auth = function(options) {
 
       var response = new Buffer(SAMLResponse);
 
-      res.set('Content-Type', 'text/html');
-      res.send(templates.form({
-        callback:        postUrl,
-        RelayState:      opts.RelayState || (req.query || {}).RelayState || (req.body || {}).RelayState || '',
-        SAMLResponse:    response.toString('base64')
-      }));
+      if (opts.responseSender) {
+        opts.responseSender(req,res, response);
+      } else {
+        res.set('Content-Type', 'text/html');
+        res.send(templates.form({
+          callback:        postUrl,
+          RelayState:      opts.RelayState || (req.query || {}).RelayState || (req.body || {}).RelayState || '',
+          SAMLResponse:    response.toString('base64')
+        }));
+      }
     });
   }
 

--- a/lib/samlp.js
+++ b/lib/samlp.js
@@ -190,7 +190,7 @@ var algorithms = {
  * - cert the public certificate
  * - key the private certificate to sign all tokens
  * - postUrl function (SAMLRequest, request, callback)
- * - responseSender(request, response, SAMLRequest) a function that handles the response. Defaults to HTML POST to postUrl.
+ * - responseHandler(request, response, SAMLRequest) a function that handles the response. Defaults to HTML POST to postUrl.
  *
  * @param  {[type]} options [description]
  * @return {[type]}         [description]
@@ -216,8 +216,8 @@ module.exports.auth = function(options) {
 
       var response = new Buffer(SAMLResponse);
 
-      if (opts.responseSender) {
-        opts.responseSender(req,res, response);
+      if (opts.responseHandler) {
+        opts.responseHandler(req,res, response);
       } else {
         res.set('Content-Type', 'text/html');
         res.send(templates.form({

--- a/lib/samlp.js
+++ b/lib/samlp.js
@@ -190,6 +190,7 @@ var algorithms = {
  * - cert the public certificate
  * - key the private certificate to sign all tokens
  * - postUrl function (SAMLRequest, request, callback)
+ * - responseSender(request, response, SAMLRequest) a function that handles the response. Defaults to HTML POST to postUrl.
  *
  * @param  {[type]} options [description]
  * @return {[type]}         [description]


### PR DESCRIPTION
I've introduced a new option to support custom responses, as with the current implementation it seemed impossible to handle SAMLResponse via XHR (or at least without postprocessing the HTML output).

The use case I was trying to cover with the change was that if you are trying to achieve a Zero Page Login flow with SAML2  via XHR requests. 
A good example for this is the following scenario: log in a user in a remote SP based on a current session token, but you are not aware of the user's credentials in the remote service. In this case you can POST the SAMLResponse via XHR, and extracting it from a HTML output makes no sense. Instead you could pass it around as JSON or an XML, or whatever format you wish, and the original caller can POST it to the original returnURL.

Please check out my changes, and if you consider them safe (not violating any protocol constraints), and it seems a reasonable change, consider merging it to the main library.