### PR TITLE
Fix for req.body not always existing

### DIFF
--- a/lib/samlp.js
+++ b/lib/samlp.js
@@ -230,7 +230,7 @@ module.exports.auth = function(options) {
   }
 
   return function (req, res, next) {
-    getSamlRequest(req.query.SAMLRequest || req.body.SAMLRequest, function(err, samlRequestDom) {
+    getSamlRequest((req.query || {}).SAMLRequest || (req.body || {}).SAMLRequest, function(err, samlRequestDom) {
       var audience = opts.audience;
       if (samlRequestDom) {
         var issuer = xpath.select("//*[local-name(.)='Issuer' and namespace-uri(.)='urn:oasis:names:tc:SAML:2.0:assertion']/text()", samlRequestDom);
@@ -251,7 +251,7 @@ module.exports.auth = function(options) {
 };
 
 module.exports.parseRequest = function(req, callback) {
-  var samlRequest = req.query.SAMLRequest || req.body.SAMLRequest;
+  var samlRequest = (req.query || {}).SAMLRequest || (req.body || {}).SAMLRequest;
   if (!samlRequest)
     return callback();
 
@@ -312,7 +312,7 @@ module.exports.logout = function (options) {
 };
 
 module.exports.parseLogoutRequest = function (req, callback) {
-  var samlRequest = req.query.SAMLRequest || req.body.SAMLRequest;
+  var samlRequest = (req.query || {}).SAMLRequest || (req.body || {}).SAMLRequest;
   if (!samlRequest) return callback();
 
   getSamlRequest(samlRequest, function(err, logoutRequestDom) {


### PR DESCRIPTION
This was causing an exception to be thrown as the body was not always defined. I used same pattern as in other places in the same file to ensure the query and body are always objects.

Not a high priority PR, but it was just bugging the bejebus out of me while trying to debug. :grimacing: