### PR TITLE
No unafe-eval in form.ejs and more parameters for responseHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Options
 | digestAlgorithm     | digest algorithm, options: sha1, sha256          | ```'sha256'``` |
 | RelayState          | state of the auth process                        | ```req.query.RelayState || req.body.RelayState``` |
 | sessionIndex          | the index of a particular session between the principal identified by the subject and the authenticating authority                        | _SessionIndex is not included_ |
-| responseHandler       | custom response handler for SAML response f(SAMLResponse, req, res, next) | HTML response that POSTS to postUrl |
+| responseHandler       | custom response handler for SAML response f(SAMLResponse, options, req, res, next) | HTML response that POSTS to postUrl |
 
 
 Add the middleware as follows:

--- a/lib/samlp.js
+++ b/lib/samlp.js
@@ -201,7 +201,7 @@ var algorithms = {
  * - cert the public certificate
  * - key the private certificate to sign all tokens
  * - postUrl function (SAMLRequest, request, callback)
- * - responseHandler(SAMLResponse, request, response, next) a function that handles the response. Defaults to HTML POST to postUrl.
+ * - responseHandler(SAMLResponse, options, request, response, next) a function that handles the response. Defaults to HTML POST to postUrl.
  *
  * @param  {[type]} options [description]
  * @return {[type]}         [description]
@@ -221,6 +221,7 @@ module.exports.auth = function(options) {
     if (!user) return res.send(401);
 
     opts.audience = audience;
+    opts.postUrl = postUrl;
 
     getSamlResponse(opts, user, function (err, SAMLResponse) {
       if (err) return next(err);
@@ -228,7 +229,7 @@ module.exports.auth = function(options) {
       var response = new Buffer(SAMLResponse);
 
       if (opts.responseHandler) {
-        opts.responseHandler(response, req, res, next);
+        opts.responseHandler(response, opts, req, res, next);
       } else {
         res.set('Content-Type', 'text/html');
         res.send(templates.form({

--- a/templates/form.ejs
+++ b/templates/form.ejs
@@ -15,7 +15,7 @@
         </noscript>
     </form>
     <script language="javascript" type="text/javascript">
-        window.setTimeout('document.forms[0].submit()', 0);
+        window.setTimeout(function(){document.forms[0].submit();}, 0);
     </script>
 </body>
 </html>


### PR DESCRIPTION
I've run into issue using Content Security Policies (https://en.wikipedia.org/wiki/Content_Security_Policy) which do not allow unsafe-eval as used in form.ejs. 

Then I've tried using a custom responseHandler but I missed the callback url and audience option to be passed along.  