### PR TITLE
New regex for verifying pem-formatted key-files.

### DIFF
--- a/lib/encoders.js
+++ b/lib/encoders.js
@@ -1,7 +1,7 @@
 var thumbprint = require('thumbprint');
 
 var removeHeaders = module.exports.removeHeaders = function  (cert) {
-  var pem = /-----BEGIN (\w*)-----([^-]*)-----END (\w*)-----/g.exec(cert.toString());
+  var pem = /-----BEGIN ([A-Z ]*)-----([^-]*)-----END ([A-Z ]*)-----/g.exec(cert.toString());
   if (pem && pem.length > 0) {
     return pem[2].replace(/[\n|\r\n]/g, '');
   }


### PR DESCRIPTION
My version of  OpenSSL generating pem-files with opening/closing lines like:
`-----BEGIN PUBLIC KEY-----`
The regex-function did not allow the extra spaces between the words PUBLIC and KEY.

This pull requests solves that issue by changing the regex: the regex now only allows capital letters and spaces in the opening and closing-lines of the pem-file.