### PR TITLE
Multiple audiences

### DIFF
--- a/lib/samlp.js
+++ b/lib/samlp.js
@@ -246,7 +246,7 @@ module.exports.auth = function(options) {
       var audience = opts.audience;
       if (samlRequestDom) {
         var issuer = xpath.select("//*[local-name(.)='Issuer' and namespace-uri(.)='urn:oasis:names:tc:SAML:2.0:assertion']/text()", samlRequestDom);
-        if (issuer && issuer.length > 0) audience = audience || issuer[0].textContent;
+        if (issuer && issuer.length > 0) audience = issuer[0].textContent;
 
         var id = samlRequestDom.documentElement.getAttribute('ID');
         if (id) opts.inResponseTo = opts.inResponseTo || id;


### PR DESCRIPTION
in order to use the samlp for multiple applications, and you have your callbacks stored in a database, you need query the right callback url. so, there was a problem when i was using different applications on the same provider, that the audience was stored in opts and therefore never gets updated, if the issuer is set.
