### PR TITLE
Add option to put a ds: prefix to signature fields, to not envelop the signature, and to put the signature after the issuer

### DIFF
--- a/lib/samlp.js
+++ b/lib/samlp.js
@@ -88,7 +88,7 @@ function buildSamlResponse(options) {
 
     sig.keyInfoProvider = {
       getKeyInfo: function () {
-        return "<" + dsPrefix + "X509Data><" + dsPrefix + "X509Certificate>" + cert + "</" + dsPrefix + "X509Certificate></" + dsPrefix + "X509Data>";
+        return "<" + dsPrefix + "X509Data><" + dsPrefix + "X509Certificate>" + pem + "</" + dsPrefix + "X509Certificate></" + dsPrefix + "X509Data>";
       }
     };
 


### PR DESCRIPTION
The SAML v2.0 XSD specifies that the signature fields should be prefixed with ds:

https://docs.oasis-open.org/security/saml/v2.0/saml-schema-protocol-2.0.xsd

I've added an option that adds this prefix to all of the signature fields.

I've also added an option to not envelop the signature, and to instead have both a signed assertion and a signed message. I've also put the signature after the Issuer field to match the specification.
