### PR TITLE
Refactored logout handling to use the sessionIndex to find the session

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -14,7 +14,9 @@ module.exports.ELEMENTS = {
     PROP: 'SAMLRequest',
     SIGNATURE_VALIDATION_PATH : "//*[local-name(.)='LogoutRequest']/*[local-name(.)='Signature' and namespace-uri(.)='http://www.w3.org/2000/09/xmldsig#']",
     SIGNATURE_LOCATION_PATH : "//*[local-name(.)='LogoutRequest' and namespace-uri(.)='urn:oasis:names:tc:SAML:2.0:protocol']",
-    ISSUER_PATH : "//*[local-name(.)='Issuer' and namespace-uri(.)='urn:oasis:names:tc:SAML:2.0:assertion']/text()"
+    ISSUER_PATH : "//*[local-name(.)='Issuer' and namespace-uri(.)='urn:oasis:names:tc:SAML:2.0:assertion']/text()",
+    SESSION_INDEX_PATH: "//*[local-name(.)='SessionIndex' and namespace-uri(.)='urn:oasis:names:tc:SAML:2.0:protocol']/text()",
+    NAME_ID: "//*[local-name(.)='NameID' and namespace-uri(.)='urn:oasis:names:tc:SAML:2.0:assertion']/text()"
   },
   LOGOUT_RESPONSE: {
     PROP: 'SAMLResponse',

--- a/lib/logout.js
+++ b/lib/logout.js
@@ -24,12 +24,13 @@ module.exports.logout = function (options) {
     // Finished if there are no more session - finish logout
     if (!sessionParticipants.hasElements()) { return finalize(transactionId, req, res, next); }
 
-    var logoutRequestState = { transactionId: transactionId };
+    sessionParticipants.getFirst(function (err, participant) {
+      // Store the sessionIndex in session so when the logout request comes back we can use that to validate
+      var logoutRequestState = { transactionId: transactionId, sessionIndex: participant.sessionIndex, issuer: participant.serviceProviderId, nameId: participant.nameId };
 
-    options.store.save(req, logoutRequestState, function (err, relayState) {
-      if (err) return next(err);
+      options.store.save(req, logoutRequestState, function (err, relayState) {
+        if (err) return next(err);
 
-      sessionParticipants.getFirst(function (err, participant) {
         // Use session to generate SAML Request
         var logoutRequest = templates.logoutrequest({
           ID: utils.generateUniqueID(),
@@ -85,7 +86,7 @@ module.exports.logout = function (options) {
     });
   }
 
-  function validateSamlResponse(req, sessionParticipants, cb) {
+  function validateSamlResponse(req, sessionParticipant, cb) {
     var SAMLResponse = req.query.SAMLResponse || req.body.SAMLResponse;
 
     function parseAndValidate(err, buffer) {
@@ -124,24 +125,20 @@ module.exports.logout = function (options) {
       }
 
       req.parsedSAMLResponse = parsedResponse;
-      sessionParticipants.get(parsedResponse.issuer, function (err, sessionParticipant) {
-        if (err) { return cb(err); }
-        if (!sessionParticipant) { return cb(new Error('Invalid Session Participant')) };
-        if (!sessionParticipant.cert) { 
-          // If there's no certificate to check the signature, let it pass
-          return cb(null, parsedResponse);
-        }
+      if (!sessionParticipant.cert) { 
+        // If there's no certificate to check the signature, let it pass
+        return cb(null, parsedResponse);
+      }
 
-        // validate signature
-        try {
-          var validationOptions = xtend({signingCert: sessionParticipant.cert}, options);
-          utils.validateSignature(req, 'LOGOUT_RESPONSE', xml, validationOptions);
-        } catch (e) {
-          return cb(e);
-        }
+      // validate signature
+      try {
+        var validationOptions = xtend({signingCert: sessionParticipant.cert}, options);
+        utils.validateSignature(req, 'LOGOUT_RESPONSE', xml, validationOptions);
+      } catch (e) {
+        return cb(e);
+      }
 
-        cb(null, parsedResponse);
-      });
+      cb(null, parsedResponse);
     }
 
     if (req.body.SAMLResponse || !options.deflate) {
@@ -158,8 +155,8 @@ module.exports.logout = function (options) {
       // SP Initated flow.
       if (req.query.SAMLRequest || req.body.SAMLRequest) {
         var opts = {
-          getCredentials: function getCredentials(issuer, cb) {
-            options.sessionParticipants.get(issuer, function (err, session) {
+          getCredentials: function getCredentials(issuer, sessionIndex, nameId, cb) {
+            options.sessionParticipants.get(issuer, sessionIndex, nameId, function (err, session) {
               if (err) { return cb(err); }
               if (!session) { return cb(new Error('Invalid Session Participant')) };
               if (!session.cert) { return cb(); };
@@ -178,7 +175,7 @@ module.exports.logout = function (options) {
             return next(new Error('SAML Request with no issuer. Issuer is a mandatory element.'));
           }
 
-          options.sessionParticipants.get(requestData.issuer, function (err, session) {
+          options.sessionParticipants.get(requestData.issuer, requestData.sessionIndex, requestData.nameId, function (err, session) {
             if (err) { return next(err); }
             if (!session && !options.destination) { return next(new Error('Invalid Session Participant')); }
 
@@ -198,9 +195,9 @@ module.exports.logout = function (options) {
               // This session is already saved in the store.
               // We should not send a LogoutRequest to that session
               // Only a LogoutResponse when there are no other session participants active
-              options.sessionParticipants.remove(requestData.issuer, function (err) {
+              options.sessionParticipants.remove(requestData.issuer, requestData.sessionIndex, requestData.nameId, function (err) {
                 if (err) { return next(err); }
-
+                
                 prepareAndSendLogoutRequest(options.sessionParticipants, transactionId, req, res, next);
               });
             });
@@ -209,9 +206,9 @@ module.exports.logout = function (options) {
 
       // Logout flow in progress, incoming SAMLResponse from SP. (Could be SP initiated or IdP initiated)
       } else if (req.query.SAMLResponse || req.body.SAMLResponse) {
-        function processLogoutResponse(logoutResponse, transactionId) {
+        function process(state, transactionId) {
           // LogoutResponse was OK, we remove the session participant from the IdP
-          options.sessionParticipants.remove(logoutResponse.issuer, function (err) {
+          options.sessionParticipants.remove(state.issuer, state.sessionIndex, state.nameId, function (err) {
             if(err) return next(err);
 
             // Continue with next session if any
@@ -225,25 +222,29 @@ module.exports.logout = function (options) {
           if (err) { return next(err); }
           if (!state) { return next(new Error('Invalid RelayState')); }
 
-          // If there are sessions left, keep sending LogoutRequest to Session Participants. If not finish
-          validateSamlResponse(req, options.sessionParticipants, function (err, logoutResponse) {
+          options.sessionParticipants.get(state.issuer, state.sessionIndex, state.nameId, function (err, sessionParticipant) {
             if (err) { return next(err); }
+            if (!sessionParticipant) { return next(new Error('Invalid Session Participant')) };
 
-            var transactionId = state.transactionId;
-            if (logoutResponse.status === STATUS.SUCCESS) {
-              return processLogoutResponse(logoutResponse, transactionId);
-            }
+            // If there are sessions left, keep sending LogoutRequest to Session Participants. If not finish
+            validateSamlResponse(req, sessionParticipant, function (err, logoutResponse) {
+              if (err) { return next(err); }
+              var transactionId = state.transactionId;
+              if (logoutResponse.status === STATUS.SUCCESS) {
+                return process(state, transactionId);
+              }
 
-            // Mark global status as partial logout if a logout does not succeed
-            options.store.load(req, transactionId, function (err, state) {
-              state.global_status = 'failed';
-              options.store.update(req, transactionId, state, function (err) {
-                if (err) { return next(err); }
-
-                processLogoutResponse(logoutResponse, transactionId);
+              // Mark global status as partial logout if a logout does not succeed
+              options.store.load(req, transactionId, function (err, globalState) {
+                globalState.global_status = 'failed';
+                options.store.update(req, transactionId, globalState, function (err) {
+                  if (err) { return next(err); }
+                  // TODO: Review - because we need to remove the session that replied, but send the response to the originator
+                  process(state, transactionId);
+                });
               });
             });
-          });
+          });                    
         });
 
       // IdP initated - Start flow - In this case we will show a 200 when complete

--- a/lib/sessionParticipants/index.js
+++ b/lib/sessionParticipants/index.js
@@ -2,6 +2,18 @@ function SessionParticipants (sessions) {
   this._participants = sessions || [];
 }
 
+function matchingIndex(issuer, sessionIndex, nameId){
+  return function(session){
+    // If we had the issuer in session and it is provided, they should match
+    if (session.serviceProviderId && issuer){
+      if (session.serviceProviderId !== issuer) { return false; }
+    }
+
+    // SessionIndex and NameID should match
+    return session.sessionIndex === sessionIndex && session.nameId === nameId;
+  }
+}
+
 /**
  * Retrieves a Session Participant object based on the issuer
  * of a SAMLRequest/SAMLResponse. The 'issuer' should be
@@ -9,13 +21,14 @@ function SessionParticipants (sessions) {
  * represents the issuer of the previous mentions request/response.
  * 
  * @issuer {string}   The string as it was received in the SAML request/response
+ * @sessionIndex {string}   The string as it was received in the SAML request/response. Only available in LogoutRequests
  * @cb     {function} The callback that will be called with '(err, sessionParticipant)'
  */
-SessionParticipants.prototype.get = function(issuer, cb) {
-  var s = this._participants.find(function (session) {
-    return session.serviceProviderId === issuer;
-  });
-
+SessionParticipants.prototype.get = function(issuer, sessionIndex, nameId, cb) {
+  // SessionIndex should be mandatory, but not issuer
+  // Let's keep using issuer only if available
+  var s = this._participants.find(matchingIndex(issuer, sessionIndex, nameId));
+  
   if (cb) { return cb(null, s); }
 };
 
@@ -47,15 +60,16 @@ SessionParticipants.prototype.getFirst = function(cb) {
  * Remove a Session Participant from the data structure.
  * 
  * @issuer {string}   The string as it was received in the SAML request/response
+ * @sessionIndex {string}   The string as it was received in the SAML request/response. Only available in LogoutRequests 
  * @cb     {function} The callback that will be called with '(err, removedElement)'
  */
-SessionParticipants.prototype.remove = function(issuer, cb) {
+SessionParticipants.prototype.remove = function(issuer, sessionIndex, nameId, cb) {
   var sessions = this._participants;
   if (!sessions || sessions.length === 0 || !issuer) { return cb(); }
   
-  var sessionIndexToRemove = sessions.findIndex(function (session) {
-    return session.serviceProviderId === issuer;
-  });
+  // SessionIndex should be mandatory, but not issuer
+  // Let's keep using issuer only if available
+  var sessionIndexToRemove = sessions.findIndex(matchingIndex(issuer, sessionIndex, nameId));
 
   var removedElement;
   // Remove the session from the array

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -44,14 +44,34 @@ module.exports.parseSamlRequest = function(req, samlRequest, type, options, call
       return cb(null, false);
     }
 
+    var issuer, sessionIndex, nameId;
     var issuerNode = xpath.select(constants.ELEMENTS[type].ISSUER_PATH, xml);
 
-    if (!issuerNode || issuerNode.length === 0) {
+    if (issuerNode && issuerNode.length > 0) {
+      issuer = issuerNode[0].textContent;
+    }
+
+    // If LogoutRequest, we should check sessionIndex too    
+    if (constants.ELEMENTS[type].SESSION_INDEX_PATH){
+      var sessionIndexNode = xpath.select(constants.ELEMENTS[type].SESSION_INDEX_PATH, xml);
+      if (sessionIndexNode && sessionIndexNode.length > 0) {
+        sessionIndex = sessionIndexNode[0].textContent;
+      }
+    }
+
+    // If LogoutRequest, we should check sessionIndex too    
+    if (constants.ELEMENTS[type].NAME_ID){
+      var nameIdNode = xpath.select(constants.ELEMENTS[type].NAME_ID, xml);
+      if (nameIdNode && nameIdNode.length > 0) {
+        nameId = nameIdNode[0].textContent;
+      }
+    }
+
+    if (!issuer && !sessionIndex && !nameId){
       return cb(null, false);
     }
 
-    var issuer = issuerNode[0].textContent;
-    options.getCredentials(issuer, function (err, credentials) {
+    options.getCredentials(issuer, sessionIndex, nameId, function (err, credentials) {
       if (!credentials){
         return cb(null, false);
       }

--- a/test/samlp.logout.custom_store.tests.js
+++ b/test/samlp.logout.custom_store.tests.js
@@ -53,7 +53,7 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
       store: testStore,
       clearIdPSession: function(cb){
         if (returnError){
-          cb(new Error('There was an error cleaning session'));
+          return cb(new Error('There was an error cleaning session'));
         }
         cb();
       },
@@ -306,7 +306,6 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
             qs: params
           }, function (err, response) {
             if (err) { return done(err); }
-
             expect(response.statusCode).to.equal(302);
             var qs = require('querystring');
 
@@ -390,7 +389,7 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
         request.get({
           jar: request.jar(),
           followRedirect: false,
-          uri: 'http://localhost:5050/logout?SAMLRequest=fZFBS8NAEIXvhf6HsPdNM2mtdWiDhSIEqgdbPHjbbqYazO7GnQ0Uf73bVDAKetnDm%2B%2FNm8cuWZmmxa17cV14pPeOOCQn01jGfrISnbfoFNeMVhliDBp36%2Fst5mmGrXfBadeIgeV%2Fh2ImH2pnRVJuVuJs8DLPM32dXZHUEB8AmsubhZpJ0sfZ4aBpNoVF5Jk7Ki0HZcNK5BnMJeQSpntYYAYI%2BbNInshzXB7HaSaK8ShJlucI7L2%2BeA2hZZxMjs4dlOeubZ0P6QfZivgt1c4sJ0P82%2F8Qi5Sb5M55o8LfDSGFXqkreexRJKPqZl1VnphFEXNv6aRM29Ag7bJ8kLaLcGxRxrNOBXxRP8Tx6KL%2B%2BrniEw%3D%3D&Signature=asidjpasjdpasjndoubvuojewprjweprj&RelayState=123&SigAlg=http%3A%2F%2Fwww.w3.org%2F2000%2F09%2Fxmldsig%23rsa-sha1'
+          uri: 'http://localhost:5050/logout?SAMLRequest=fZFPS8NAEMXv%2FRRh75tm0lrr0AYLRQhUD1Y8eNtuphrM%2FnFnA8VP7zbFUgW97OHN782bxy5Ymc7jxr26Pj7SR08cs4PpLOMwWYo%2BWHSKW0arDDFGjdvV%2FQbLvEAfXHTadeLC8r9DMVOIrbMiq9dLcTQEWZaFvi6uSGpIDwDN5M1cTSXp%2FXS30zSdwDzxzD3VlqOycSnKAmYSSgmTJ5hjAQjli8ieKXBansZ5IapRli2OCThYQ%2FUWo2ccj%2FfO7VTg3nsXYv5JtiF%2Bz7Uzi%2FElfrY%2FpBr1Ortzwaj4dz%2FIYVDaRu4HFMmotls1TSBmUaXYWzoo4zu6CDstP4d53CY4dajTVYcKTtQvdfSt%2Fvi36gs%3D&Signature=asidjpasjdpasjndoubvuojewprjweprj&RelayState=123&SigAlg=http%3A%2F%2Fwww.w3.org%2F2000%2F09%2Fxmldsig%23rsa-sha1'
         }, function (err, res){
           if(err) return done(err);
           response = res;
@@ -1087,7 +1086,6 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
           if(err) return done(err);
           expect(response.statusCode).to.equal(200);
           $ = cheerio.load(response.body);
-          // 
           SAMLRequest = $('input[name="SAMLRequest"]').attr('value');
           sessionParticipantLogoutRequestRelayState = $('input[name="RelayState"]').attr('value');
           sessionParticipantLogoutRequest = new Buffer(SAMLRequest, 'base64').toString();
@@ -1159,7 +1157,7 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
           uri: 'http://localhost:5050/logout',
           json: true,
           body: {
-            SAMLRequest: 'PHNhbWxwOkxvZ291dFJlcXVlc3QgeG1sbnM6c2FtbHA9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDpwcm90b2NvbCIgeG1sbnM6c2FtbD0idXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOmFzc2VydGlvbiIgSUQ9InNhbWxyLTIyMGM3MDVlLWMxNWUtMTFlNi05OGE0LWVjZjRiYmNlNDMxOCIgSXNzdWVJbnN0YW50PSIyMDE2LTEyLTEzVDE4OjAxOjEyWiIgVmVyc2lvbj0iMi4wIj4KICA8c2FtbDpJc3N1ZXI+aHR0cHM6Ly9mb29iYXJzdXBwb3J0LnplbmRlc2suY29tPC9zYW1sOklzc3Vlcj48ZHM6U2lnbmF0dXJlIHhtbG5zOmRzPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwLzA5L3htbGRzaWcjIj48ZHM6U2lnbmVkSW5mbz48ZHM6Q2Fub25pY2FsaXphdGlvbk1ldGhvZCBBbGdvcml0aG09Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvMTAveG1sLWV4Yy1jMTRuIyIvPjxkczpTaWduYXR1cmVNZXRob2QgQWxnb3JpdGhtPSJodHRwOi8vd3d3LnczLm9yZy8yMDAxLzA0L3htbGRzaWctbW9yZSNyc2Etc2hhMjU2Ii8+PGRzOlJlZmVyZW5jZSBVUkk9IiNzYW1sci0yMjBjNzA1ZS1jMTVlLTExZTYtOThhNC1lY2Y0YmJjZTQzMTgiPjxkczpUcmFuc2Zvcm1zPjxkczpUcmFuc2Zvcm0gQWxnb3JpdGhtPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwLzA5L3htbGRzaWcjZW52ZWxvcGVkLXNpZ25hdHVyZSIvPjxkczpUcmFuc2Zvcm0gQWxnb3JpdGhtPSJodHRwOi8vd3d3LnczLm9yZy8yMDAxLzEwL3htbC1leGMtYzE0biMiLz48L2RzOlRyYW5zZm9ybXM+PGRzOkRpZ2VzdE1ldGhvZCBBbGdvcml0aG09Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvMDQveG1sZW5jI3NoYTI1NiIvPjxkczpEaWdlc3RWYWx1ZT5tV1RvQUJuVExDd0xJOEFFOW1RYnFTZ3NCVnNsOXNpWG9sMG9yVXVUa0dBPTwvZHM6RGlnZXN0VmFsdWU+PC9kczpSZWZlcmVuY2U+PC9kczpTaWduZWRJbmZvPjxkczpTaWduYXR1cmVWYWx1ZT5hc2lkanBhc2pkcGFzam5kb3VidnVvamV3cHJqd2Vwcmo8L2RzOlNpZ25hdHVyZVZhbHVlPjxkczpLZXlJbmZvPjxkczpYNTA5RGF0YS8+PC9kczpLZXlJbmZvPjwvZHM6U2lnbmF0dXJlPgogIDxzYW1sOk5hbWVJRCBGb3JtYXQ9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjEuMTpuYW1laWQtZm9ybWF0OmVtYWlsQWRkcmVzcyI+Zm9vQGV4YW1wbGUuY29tPC9zYW1sOk5hbWVJRD4KICA8c2FtbDpTZXNzaW9uSW5kZXg+MTwvc2FtbDpTZXNzaW9uSW5kZXg+Cjwvc2FtbHA6TG9nb3V0UmVxdWVzdD4=',
+            SAMLRequest: 'PHNhbWxwOkxvZ291dFJlcXVlc3QgeG1sbnM6c2FtbHA9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDpwcm90b2NvbCIgeG1sbnM6c2FtbD0idXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOmFzc2VydGlvbiIgSUQ9InNhbWxyLTIyMGM3MDVlLWMxNWUtMTFlNi05OGE0LWVjZjRiYmNlNDMxOCIgSXNzdWVJbnN0YW50PSIyMDE2LTEyLTEzVDE4OjAxOjEyWiIgVmVyc2lvbj0iMi4wIj4KICAgIDxzYW1sOklzc3Vlcj5odHRwczovL2Zvb2JhcnN1cHBvcnQuemVuZGVzay5jb208L3NhbWw6SXNzdWVyPjxkczpTaWduYXR1cmUgeG1sbnM6ZHM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvMDkveG1sZHNpZyMiPjxkczpTaWduZWRJbmZvPjxkczpDYW5vbmljYWxpemF0aW9uTWV0aG9kIEFsZ29yaXRobT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS8xMC94bWwtZXhjLWMxNG4jIi8+PGRzOlNpZ25hdHVyZU1ldGhvZCBBbGdvcml0aG09Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvMDQveG1sZHNpZy1tb3JlI3JzYS1zaGEyNTYiLz48ZHM6UmVmZXJlbmNlIFVSST0iI3NhbWxyLTIyMGM3MDVlLWMxNWUtMTFlNi05OGE0LWVjZjRiYmNlNDMxOCI+PGRzOlRyYW5zZm9ybXM+PGRzOlRyYW5zZm9ybSBBbGdvcml0aG09Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvMDkveG1sZHNpZyNlbnZlbG9wZWQtc2lnbmF0dXJlIi8+PGRzOlRyYW5zZm9ybSBBbGdvcml0aG09Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvMTAveG1sLWV4Yy1jMTRuIyIvPjwvZHM6VHJhbnNmb3Jtcz48ZHM6RGlnZXN0TWV0aG9kIEFsZ29yaXRobT0iaHR0cDovL3d3dy53My5vcmcvMjAwMS8wNC94bWxlbmMjc2hhMjU2Ii8+PGRzOkRpZ2VzdFZhbHVlPkxYODU1SWtuZ1NUczRUTmNqMnVHaWcrdWdla0J3N0dpd1FKRC9WTVJFV3c9PC9kczpEaWdlc3RWYWx1ZT48L2RzOlJlZmVyZW5jZT48L2RzOlNpZ25lZEluZm8+PGRzOlNpZ25hdHVyZVZhbHVlPmFzaWRqcGFzamRwYXNqbmRvdWJ2dW9qZXdwcmp3ZXByajwvZHM6U2lnbmF0dXJlVmFsdWU+PGRzOktleUluZm8+PGRzOlg1MDlEYXRhLz48L2RzOktleUluZm8+PC9kczpTaWduYXR1cmU+CiAgICAKICAgIDxzYW1sOk5hbWVJRCBGb3JtYXQ9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjEuMTpuYW1laWQtZm9ybWF0OmVtYWlsQWRkcmVzcyI+Zm9vQGV4YW1wbGUuY29tPC9zYW1sOk5hbWVJRD4KICAgIDxzYW1scDpTZXNzaW9uSW5kZXg+MTwvc2FtbHA6U2Vzc2lvbkluZGV4Pgo8L3NhbWxwOkxvZ291dFJlcXVlc3Q+',
             RelayState: '123'
           }
         }, function (err, res){

--- a/test/samlp.logout.session_store.tests.js
+++ b/test/samlp.logout.session_store.tests.js
@@ -50,7 +50,7 @@ describe('samlp logout with Session Participants - Session Provider', function (
       issuer: samlIdPIssuer,
       clearIdPSession: function(cb){
         if (returnError){
-          cb(new Error('There was an error cleaning session'));
+          return cb(new Error('There was an error cleaning session'));
         }
         cb();
       },
@@ -377,7 +377,7 @@ describe('samlp logout with Session Participants - Session Provider', function (
         request.get({
           jar: request.jar(),
           followRedirect: false,
-          uri: 'http://localhost:5050/logout?SAMLRequest=fZFBS8NAEIXvhf6HsPdNM2mtdWiDhSIEqgdbPHjbbqYazO7GnQ0Uf73bVDAKetnDm%2B%2FNm8cuWZmmxa17cV14pPeOOCQn01jGfrISnbfoFNeMVhliDBp36%2Fst5mmGrXfBadeIgeV%2Fh2ImH2pnRVJuVuJs8DLPM32dXZHUEB8AmsubhZpJ0sfZ4aBpNoVF5Jk7Ki0HZcNK5BnMJeQSpntYYAYI%2BbNInshzXB7HaSaK8ShJlucI7L2%2BeA2hZZxMjs4dlOeubZ0P6QfZivgt1c4sJ0P82%2F8Qi5Sb5M55o8LfDSGFXqkreexRJKPqZl1VnphFEXNv6aRM29Ag7bJ8kLaLcGxRxrNOBXxRP8Tx6KL%2B%2BrniEw%3D%3D&Signature=asidjpasjdpasjndoubvuojewprjweprj&RelayState=123&SigAlg=http%3A%2F%2Fwww.w3.org%2F2000%2F09%2Fxmldsig%23rsa-sha1'
+          uri: 'http://localhost:5050/logout?SAMLRequest=fZFPS8NAEMXv%2FRRh75tm0lrr0AYLRQhUD1Y8eNtuphrM%2FnFnA8VP7zbFUgW97OHN782bxy5Ymc7jxr26Pj7SR08cs4PpLOMwWYo%2BWHSKW0arDDFGjdvV%2FQbLvEAfXHTadeLC8r9DMVOIrbMiq9dLcTQEWZaFvi6uSGpIDwDN5M1cTSXp%2FXS30zSdwDzxzD3VlqOycSnKAmYSSgmTJ5hjAQjli8ieKXBansZ5IapRli2OCThYQ%2FUWo2ccj%2FfO7VTg3nsXYv5JtiF%2Bz7Uzi%2FElfrY%2FpBr1Ortzwaj4dz%2FIYVDaRu4HFMmotls1TSBmUaXYWzoo4zu6CDstP4d53CY4dajTVYcKTtQvdfSt%2Fvi36gs%3D&Signature=asidjpasjdpasjndoubvuojewprjweprj&RelayState=123&SigAlg=http%3A%2F%2Fwww.w3.org%2F2000%2F09%2Fxmldsig%23rsa-sha1'
         }, function (err, res){
           if(err) return done(err);
           response = res;
@@ -388,6 +388,76 @@ describe('samlp logout with Session Participants - Session Provider', function (
       it('should return invalid signture error', function(){
         expect(response.statusCode).to.equal(400);
         expect(response.body).to.equal('Signature check errors: The signature provided (asidjpasjdpasjndoubvuojewprjweprj) does not match the one calculated');
+      });
+    });
+
+    describe('SP initiated - Session Index does not match an active session', function () {
+      var response;
+
+      before(function () {
+        sessions.splice(0);
+        sessions.push(sessionParticipant1);
+      });
+
+      // SAMLRequest: base64 encoded + deflated + URLEncoded
+      // Signature: URLEncoded
+      // SigAlg: URLEncoded
+
+      // <samlp:LogoutRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="samlr-220c705e-c15e-11e6-98a4-ecf4bbce4318" IssueInstant="2016-12-13T18:01:12Z" Version="2.0">
+      //   <saml:Issuer>https://foobarsupport.zendesk.com</saml:Issuer>
+      //   <saml:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">foo@example.com</saml:NameID>
+      //   <saml:SessionIndex>123</saml:SessionIndex>
+      // </samlp:LogoutRequest>
+      before(function (done) {
+        request.get({
+          jar: request.jar(),
+          followRedirect: false,
+          uri: 'http://localhost:5050/logout?SAMLRequest=fZFBSwMxEIXv%2FRVL7tnupLXWoV0sFGGherDiwVuaneriJlkzWSj%2BetOtaBX0ksOb782bRxasbdvhxj%2F7Pt7TW08cs4NtHeMwWYo%2BOPSaG0anLTFGg9vV7QZVXmAXfPTGt%2BLM8r9DM1OIjXciq9ZLcTQEqVRhLosLkgbSA0AzeTXXU0lmP93tDE0nME88c0%2BV46hdXApVwEyCkjB5gDkWgKCeRPZIgdPyNM4LUY6ybHFMwMEaypcYO8bxeO%2F9Tgfuu86HmL%2BTq4lfc%2BPtYnyOf9nvUo1qnd34YHX8ux%2FkMChNLfcDimR1067qOhCzKFPsNR207Vo6Czst%2Fw7bJjZVqNJRhxLU5BP7IY9O4q9%2FKz8A&Signature=asidjpasjdpasjndoubvuojewprjweprj&RelayState=123&SigAlg=http%3A%2F%2Fwww.w3.org%2F2000%2F09%2Fxmldsig%23rsa-sha1'
+        }, function (err, res){
+          if(err) return done(err);
+          response = res;
+          done();
+        });
+      });
+
+      it('should return invalid session participant', function(){
+        expect(response.statusCode).to.equal(400);
+        expect(response.body).to.equal('Invalid Session Participant');        
+      });
+    });
+
+    describe('SP initiated - NameID does not match an active session', function () {
+      var response;
+
+      before(function () {
+        sessions.splice(0);
+        sessions.push(sessionParticipant1);
+      });
+
+      // SAMLRequest: base64 encoded + deflated + URLEncoded
+      // Signature: URLEncoded
+      // SigAlg: URLEncoded
+
+      // <samlp:LogoutRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="samlr-220c705e-c15e-11e6-98a4-ecf4bbce4318" IssueInstant="2016-12-13T18:01:12Z" Version="2.0">
+      //   <saml:Issuer>https://foobarsupport.zendesk.com</saml:Issuer>
+      //   <saml:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">bar@example.com</saml:NameID>
+      //   <saml:SessionIndex>1</saml:SessionIndex>
+      // </samlp:LogoutRequest>
+      before(function (done) {
+        request.get({
+          jar: request.jar(),
+          followRedirect: false,
+          uri: 'http://localhost:5050/logout?SAMLRequest=fZHBTsMwEETv%2FYrId6fZNJSyaiMqVUiRCgeKOHBznS1ExHbwOlLF1%2BOmCAISXHyYfbOzIy9ZmbbDrXt2fbint544JEfTWsZhshK9t%2BgUN4xWGWIMGnfr2y3maYadd8Fp14qR5X%2BHYiYfGmdFUm1W4mTwMs8zfZldkNQQHwCay6uFKiTpQ7HfaypmsIg8c0%2BV5aBsWIk8g7mEXMLsARaYAUL%2BJJJH8hyXx3GaiXKSJMtTAg5WX76E0DFOpwfn9spz33XOh%2FSdbE38mmpnltMx%2FmW%2FizWqTXLjvFHh736QwqA0tTwMKJJRTbuua0%2FMooyZ13RUpmtpFHZe%2Fh22i2ysUMWjjiV8Qj%2FEyVn89WvlBw%3D%3D&Signature=asidjpasjdpasjndoubvuojewprjweprj&RelayState=123&SigAlg=http%3A%2F%2Fwww.w3.org%2F2000%2F09%2Fxmldsig%23rsa-sha1'
+        }, function (err, res){
+          if(err) return done(err);
+          response = res;
+          done();
+        });
+      });
+
+      it('should return invalid session participant', function(){
+        expect(response.statusCode).to.equal(400);
+        expect(response.body).to.equal('Invalid Session Participant');
       });
     });
 
@@ -1120,7 +1190,7 @@ describe('samlp logout with Session Participants - Session Provider', function (
           uri: 'http://localhost:5050/logout',
           json: true,
           body: {
-            SAMLRequest: 'PHNhbWxwOkxvZ291dFJlcXVlc3QgeG1sbnM6c2FtbHA9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDpwcm90b2NvbCIgeG1sbnM6c2FtbD0idXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOmFzc2VydGlvbiIgSUQ9InNhbWxyLTIyMGM3MDVlLWMxNWUtMTFlNi05OGE0LWVjZjRiYmNlNDMxOCIgSXNzdWVJbnN0YW50PSIyMDE2LTEyLTEzVDE4OjAxOjEyWiIgVmVyc2lvbj0iMi4wIj4KICA8c2FtbDpJc3N1ZXI+aHR0cHM6Ly9mb29iYXJzdXBwb3J0LnplbmRlc2suY29tPC9zYW1sOklzc3Vlcj48ZHM6U2lnbmF0dXJlIHhtbG5zOmRzPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwLzA5L3htbGRzaWcjIj48ZHM6U2lnbmVkSW5mbz48ZHM6Q2Fub25pY2FsaXphdGlvbk1ldGhvZCBBbGdvcml0aG09Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvMTAveG1sLWV4Yy1jMTRuIyIvPjxkczpTaWduYXR1cmVNZXRob2QgQWxnb3JpdGhtPSJodHRwOi8vd3d3LnczLm9yZy8yMDAxLzA0L3htbGRzaWctbW9yZSNyc2Etc2hhMjU2Ii8+PGRzOlJlZmVyZW5jZSBVUkk9IiNzYW1sci0yMjBjNzA1ZS1jMTVlLTExZTYtOThhNC1lY2Y0YmJjZTQzMTgiPjxkczpUcmFuc2Zvcm1zPjxkczpUcmFuc2Zvcm0gQWxnb3JpdGhtPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwLzA5L3htbGRzaWcjZW52ZWxvcGVkLXNpZ25hdHVyZSIvPjxkczpUcmFuc2Zvcm0gQWxnb3JpdGhtPSJodHRwOi8vd3d3LnczLm9yZy8yMDAxLzEwL3htbC1leGMtYzE0biMiLz48L2RzOlRyYW5zZm9ybXM+PGRzOkRpZ2VzdE1ldGhvZCBBbGdvcml0aG09Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvMDQveG1sZW5jI3NoYTI1NiIvPjxkczpEaWdlc3RWYWx1ZT5tV1RvQUJuVExDd0xJOEFFOW1RYnFTZ3NCVnNsOXNpWG9sMG9yVXVUa0dBPTwvZHM6RGlnZXN0VmFsdWU+PC9kczpSZWZlcmVuY2U+PC9kczpTaWduZWRJbmZvPjxkczpTaWduYXR1cmVWYWx1ZT5hc2lkanBhc2pkcGFzam5kb3VidnVvamV3cHJqd2Vwcmo8L2RzOlNpZ25hdHVyZVZhbHVlPjxkczpLZXlJbmZvPjxkczpYNTA5RGF0YS8+PC9kczpLZXlJbmZvPjwvZHM6U2lnbmF0dXJlPgogIDxzYW1sOk5hbWVJRCBGb3JtYXQ9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjEuMTpuYW1laWQtZm9ybWF0OmVtYWlsQWRkcmVzcyI+Zm9vQGV4YW1wbGUuY29tPC9zYW1sOk5hbWVJRD4KICA8c2FtbDpTZXNzaW9uSW5kZXg+MTwvc2FtbDpTZXNzaW9uSW5kZXg+Cjwvc2FtbHA6TG9nb3V0UmVxdWVzdD4=',
+            SAMLRequest: 'PHNhbWxwOkxvZ291dFJlcXVlc3QgeG1sbnM6c2FtbHA9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDpwcm90b2NvbCIgeG1sbnM6c2FtbD0idXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOmFzc2VydGlvbiIgSUQ9InNhbWxyLTIyMGM3MDVlLWMxNWUtMTFlNi05OGE0LWVjZjRiYmNlNDMxOCIgSXNzdWVJbnN0YW50PSIyMDE2LTEyLTEzVDE4OjAxOjEyWiIgVmVyc2lvbj0iMi4wIj4KICA8c2FtbDpJc3N1ZXI+aHR0cHM6Ly9mb29iYXJzdXBwb3J0LnplbmRlc2suY29tPC9zYW1sOklzc3Vlcj48ZHM6U2lnbmF0dXJlIHhtbG5zOmRzPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwLzA5L3htbGRzaWcjIj48ZHM6U2lnbmVkSW5mbz48ZHM6Q2Fub25pY2FsaXphdGlvbk1ldGhvZCBBbGdvcml0aG09Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvMTAveG1sLWV4Yy1jMTRuIyIvPjxkczpTaWduYXR1cmVNZXRob2QgQWxnb3JpdGhtPSJodHRwOi8vd3d3LnczLm9yZy8yMDAxLzA0L3htbGRzaWctbW9yZSNyc2Etc2hhMjU2Ii8+PGRzOlJlZmVyZW5jZSBVUkk9IiNzYW1sci0yMjBjNzA1ZS1jMTVlLTExZTYtOThhNC1lY2Y0YmJjZTQzMTgiPjxkczpUcmFuc2Zvcm1zPjxkczpUcmFuc2Zvcm0gQWxnb3JpdGhtPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwLzA5L3htbGRzaWcjZW52ZWxvcGVkLXNpZ25hdHVyZSIvPjxkczpUcmFuc2Zvcm0gQWxnb3JpdGhtPSJodHRwOi8vd3d3LnczLm9yZy8yMDAxLzEwL3htbC1leGMtYzE0biMiLz48L2RzOlRyYW5zZm9ybXM+PGRzOkRpZ2VzdE1ldGhvZCBBbGdvcml0aG09Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvMDQveG1sZW5jI3NoYTI1NiIvPjxkczpEaWdlc3RWYWx1ZT5YRENVcm5mbENKUTJ3bVV5bmFWaDRDRnZNOUx2MHdUTXBUSUkxbEVtTi9FPTwvZHM6RGlnZXN0VmFsdWU+PC9kczpSZWZlcmVuY2U+PC9kczpTaWduZWRJbmZvPjxkczpTaWduYXR1cmVWYWx1ZT5hc2lkanBhc2pkcGFzam5kb3VidnVvamV3cHJqd2Vwcmo8L2RzOlNpZ25hdHVyZVZhbHVlPjxkczpLZXlJbmZvPjxkczpYNTA5RGF0YS8+PC9kczpLZXlJbmZvPjwvZHM6U2lnbmF0dXJlPgogIDxzYW1sOk5hbWVJRCBGb3JtYXQ9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjEuMTpuYW1laWQtZm9ybWF0OmVtYWlsQWRkcmVzcyI+Zm9vQGV4YW1wbGUuY29tPC9zYW1sOk5hbWVJRD4KICA8c2FtbHA6U2Vzc2lvbkluZGV4PjE8L3NhbWxwOlNlc3Npb25JbmRleD4KPC9zYW1scDpMb2dvdXRSZXF1ZXN0Pg==',
             RelayState: '123'
           }
         }, function (err, res){
@@ -1137,6 +1207,84 @@ describe('samlp logout with Session Participants - Session Provider', function (
         expect(response.body).to.equal('Signature check errors: invalid signature: the signature value asidjpasjdpasjndoubvuojewprjweprj is incorrect');
       });
     });
+
+    describe('SP initiated - Session Index does not match an active session', function(){
+      var response;
+
+      before(function () {
+        sessions.splice(0);
+        sessions.push({
+          serviceProviderId : 'https://foobarsupport.zendesk.com',
+          nameId: 'foo@example.com',
+          sessionIndex: '1',
+          serviceProviderLogoutURL: 'https://example.com/logout',
+          cert: sp1_credentials.cert
+        });
+      });
+
+      before(function (done) {
+        request.post({
+          jar: request.jar(),
+          followRedirect: false,
+          uri: 'http://localhost:5050/logout',
+          json: true,
+          body: {
+            // Different sessionIndex
+            SAMLRequest: 'PHNhbWxwOkxvZ291dFJlcXVlc3QgeG1sbnM6c2FtbHA9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDpwcm90b2NvbCIgeG1sbnM6c2FtbD0idXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOmFzc2VydGlvbiIgSUQ9InNhbWxyLTIyMGM3MDVlLWMxNWUtMTFlNi05OGE0LWVjZjRiYmNlNDMxOCIgSXNzdWVJbnN0YW50PSIyMDE2LTEyLTEzVDE4OjAxOjEyWiIgVmVyc2lvbj0iMi4wIj4KICA8c2FtbDpJc3N1ZXI+aHR0cHM6Ly9mb29iYXJzdXBwb3J0LnplbmRlc2suY29tPC9zYW1sOklzc3Vlcj48ZHM6U2lnbmF0dXJlIHhtbG5zOmRzPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwLzA5L3htbGRzaWcjIj48ZHM6U2lnbmVkSW5mbz48ZHM6Q2Fub25pY2FsaXphdGlvbk1ldGhvZCBBbGdvcml0aG09Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvMTAveG1sLWV4Yy1jMTRuIyIvPjxkczpTaWduYXR1cmVNZXRob2QgQWxnb3JpdGhtPSJodHRwOi8vd3d3LnczLm9yZy8yMDAxLzA0L3htbGRzaWctbW9yZSNyc2Etc2hhMjU2Ii8+PGRzOlJlZmVyZW5jZSBVUkk9IiNzYW1sci0yMjBjNzA1ZS1jMTVlLTExZTYtOThhNC1lY2Y0YmJjZTQzMTgiPjxkczpUcmFuc2Zvcm1zPjxkczpUcmFuc2Zvcm0gQWxnb3JpdGhtPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwLzA5L3htbGRzaWcjZW52ZWxvcGVkLXNpZ25hdHVyZSIvPjxkczpUcmFuc2Zvcm0gQWxnb3JpdGhtPSJodHRwOi8vd3d3LnczLm9yZy8yMDAxLzEwL3htbC1leGMtYzE0biMiLz48L2RzOlRyYW5zZm9ybXM+PGRzOkRpZ2VzdE1ldGhvZCBBbGdvcml0aG09Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvMDQveG1sZW5jI3NoYTI1NiIvPjxkczpEaWdlc3RWYWx1ZT5tV1RvQUJuVExDd0xJOEFFOW1RYnFTZ3NCVnNsOXNpWG9sMG9yVXVUa0dBPTwvZHM6RGlnZXN0VmFsdWU+PC9kczpSZWZlcmVuY2U+PC9kczpTaWduZWRJbmZvPjxkczpTaWduYXR1cmVWYWx1ZT5hc2lkanBhc2pkcGFzam5kb3VidnVvamV3cHJqd2Vwcmo8L2RzOlNpZ25hdHVyZVZhbHVlPjxkczpLZXlJbmZvPjxkczpYNTA5RGF0YS8+PC9kczpLZXlJbmZvPjwvZHM6U2lnbmF0dXJlPgogIDxzYW1sOk5hbWVJRCBGb3JtYXQ9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjEuMTpuYW1laWQtZm9ybWF0OmVtYWlsQWRkcmVzcyI+Zm9vQGV4YW1wbGUuY29tPC9zYW1sOk5hbWVJRD4KICA8c2FtbDpTZXNzaW9uSW5kZXg+MTIzPC9zYW1sOlNlc3Npb25JbmRleD4KPC9zYW1scDpMb2dvdXRSZXF1ZXN0Pg==',
+            RelayState: '123'
+          }
+        }, function (err, res){
+          if(err) return done(err);
+          response = res;
+
+          done();
+        });
+      });
+
+      it('should return invalid session participant', function () {
+        expect(response.statusCode).to.equal(400);
+        expect(response.body).to.equal('Invalid Session Participant');
+      });
+    });
+
+    describe('SP initiated - NameID does not match an active session', function(){
+      var response;
+
+      before(function () {
+        sessions.splice(0);
+        sessions.push({
+          serviceProviderId : 'https://foobarsupport.zendesk.com',
+          nameId: 'foo@example.com',
+          sessionIndex: '1',
+          serviceProviderLogoutURL: 'https://example.com/logout',
+          cert: sp1_credentials.cert
+        });
+      });
+
+      before(function (done) {
+        request.post({
+          jar: request.jar(),
+          followRedirect: false,
+          uri: 'http://localhost:5050/logout',
+          json: true,
+          body: {
+            // Different nameID
+            SAMLRequest: 'PHNhbWxwOkxvZ291dFJlcXVlc3QgeG1sbnM6c2FtbHA9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjIuMDpwcm90b2NvbCIgeG1sbnM6c2FtbD0idXJuOm9hc2lzOm5hbWVzOnRjOlNBTUw6Mi4wOmFzc2VydGlvbiIgSUQ9InNhbWxyLTIyMGM3MDVlLWMxNWUtMTFlNi05OGE0LWVjZjRiYmNlNDMxOCIgSXNzdWVJbnN0YW50PSIyMDE2LTEyLTEzVDE4OjAxOjEyWiIgVmVyc2lvbj0iMi4wIj4KICA8c2FtbDpJc3N1ZXI+aHR0cHM6Ly9mb29iYXJzdXBwb3J0LnplbmRlc2suY29tPC9zYW1sOklzc3Vlcj48ZHM6U2lnbmF0dXJlIHhtbG5zOmRzPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwLzA5L3htbGRzaWcjIj48ZHM6U2lnbmVkSW5mbz48ZHM6Q2Fub25pY2FsaXphdGlvbk1ldGhvZCBBbGdvcml0aG09Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvMTAveG1sLWV4Yy1jMTRuIyIvPjxkczpTaWduYXR1cmVNZXRob2QgQWxnb3JpdGhtPSJodHRwOi8vd3d3LnczLm9yZy8yMDAxLzA0L3htbGRzaWctbW9yZSNyc2Etc2hhMjU2Ii8+PGRzOlJlZmVyZW5jZSBVUkk9IiNzYW1sci0yMjBjNzA1ZS1jMTVlLTExZTYtOThhNC1lY2Y0YmJjZTQzMTgiPjxkczpUcmFuc2Zvcm1zPjxkczpUcmFuc2Zvcm0gQWxnb3JpdGhtPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwLzA5L3htbGRzaWcjZW52ZWxvcGVkLXNpZ25hdHVyZSIvPjxkczpUcmFuc2Zvcm0gQWxnb3JpdGhtPSJodHRwOi8vd3d3LnczLm9yZy8yMDAxLzEwL3htbC1leGMtYzE0biMiLz48L2RzOlRyYW5zZm9ybXM+PGRzOkRpZ2VzdE1ldGhvZCBBbGdvcml0aG09Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvMDQveG1sZW5jI3NoYTI1NiIvPjxkczpEaWdlc3RWYWx1ZT5tV1RvQUJuVExDd0xJOEFFOW1RYnFTZ3NCVnNsOXNpWG9sMG9yVXVUa0dBPTwvZHM6RGlnZXN0VmFsdWU+PC9kczpSZWZlcmVuY2U+PC9kczpTaWduZWRJbmZvPjxkczpTaWduYXR1cmVWYWx1ZT5hc2lkanBhc2pkcGFzam5kb3VidnVvamV3cHJqd2Vwcmo8L2RzOlNpZ25hdHVyZVZhbHVlPjxkczpLZXlJbmZvPjxkczpYNTA5RGF0YS8+PC9kczpLZXlJbmZvPjwvZHM6U2lnbmF0dXJlPgogIDxzYW1sOk5hbWVJRCBGb3JtYXQ9InVybjpvYXNpczpuYW1lczp0YzpTQU1MOjEuMTpuYW1laWQtZm9ybWF0OmVtYWlsQWRkcmVzcyI+YmFyQGV4YW1wbGUuY29tPC9zYW1sOk5hbWVJRD4KICA8c2FtbDpTZXNzaW9uSW5kZXg+MTwvc2FtbDpTZXNzaW9uSW5kZXg+Cjwvc2FtbHA6TG9nb3V0UmVxdWVzdD4=',
+            RelayState: '123'
+          }
+        }, function (err, res){
+          if(err) return done(err);
+          response = res;
+
+          done();
+        });
+      });
+
+      it('should return invalid session participant', function () {
+        expect(response.statusCode).to.equal(400);
+        expect(response.body).to.equal('Invalid Session Participant');
+      });
+    });
   });
 });
 
@@ -1151,7 +1299,7 @@ describe('samlp logout with Session Participants - Session Provider', function (
       issuer: samlIdPIssuer,
       clearIdPSession: function(cb){
         if (returnError){
-          cb(new Error('There was an error cleaning session'));
+          return cb(new Error('There was an error cleaning session'));
         }
         cb();
       },


### PR DESCRIPTION
We were using only the audience to search for the session participant. We should use the NameID and sessionIndex. Update the sessionParticipants get and remove methods to receive the nameId and sessionIndex as parameters.

I've also stored audience, sessionIndex and nameId in the state before issuing a LogoutRequest, so when the flow resumes back, we have all the information in the context to retrieve the session participant