### PR TITLE
Don't use unafe-eval in form.ejs

### DIFF
--- a/templates/form.ejs
+++ b/templates/form.ejs
@@ -15,7 +15,7 @@
         </noscript>
     </form>
     <script language="javascript" type="text/javascript">
-        window.setTimeout('document.forms[0].submit()', 0);
+        window.setTimeout(function(){document.forms[0].submit();}, 0);
     </script>
 </body>
 </html>


### PR DESCRIPTION
I had submitted this earlier ( https://github.com/auth0/node-samlp/pull/23 ) but seem to have disappeared in 8bfb4fc553d650bdd7ffa7cf8af1f1ab4b505eea this pull request is to bring it back.

 @mcastany any reason we can't merge this?   