### PR TITLE
SAMLResponse Assertion wrongfully placed at end of XML instead of after issuer

### DIFF
--- a/lib/samlp.js
+++ b/lib/samlp.js
@@ -5,6 +5,7 @@ var xtend                 = require('xtend');
 var utils                 = require('./utils');
 var templates             = require('./templates');
 var encoders              = require('./encoders');
+var signers               = require('./signers');
 var PassportProfileMapper = require('./claims/PassportProfileMapper');
 var constants             = require('./constants');
 
@@ -29,27 +30,8 @@ function buildSamlResponse(options) {
       .replace(/>(\s*)</g, '><') //unindent
       .trim();
 
-    var sig = new SignedXml(null, {
-      signatureAlgorithm: constants.ALGORITHMS.SIGNATURE[options.signatureAlgorithm]
-    });
-
-    sig.addReference(
-      constants.ELEMENTS.RESPONSE.SIGNATURE_LOCATION_PATH,
-      ["http://www.w3.org/2000/09/xmldsig#enveloped-signature", "http://www.w3.org/2001/10/xml-exc-c14n#"],
-      constants.ALGORITHMS.DIGEST[options.digestAlgorithm]);
-
-    sig.signingKey = options.key;
-
-    var pem = encoders.removeHeaders(options.cert);
-    sig.keyInfoProvider = {
-      getKeyInfo: function (key, prefix) {
-        prefix = prefix ? prefix + ':' : prefix;
-        return "<" + prefix + "X509Data><" + prefix + "X509Certificate>" + pem + "</" + prefix + "X509Certificate></" + prefix + "X509Data>";
-      }
-    };
-
-    sig.computeSignature(cannonicalized, { prefix: options.signatureNamespacePrefix });
-    SAMLResponse = sig.getSignedXml();
+      options.reference = constants.ELEMENTS.RESPONSE.SIGNATURE_LOCATION_PATH;
+      return signers.signXml(options, cannonicalized);
   }
 
   return SAMLResponse;


### PR DESCRIPTION
I thought we could use the signing function we already have containing the fix from #42 to fix the SAMLResponse signing issue. The Signature is now at the end of the XML instead of after the issuer.

#29 also fixes this but introduces some other changes (features) as well. Created this pull request so we can just fix this bug.