### PR TITLE
Add options for location of Response signature in message

### DIFF
--- a/lib/samlp.js
+++ b/lib/samlp.js
@@ -48,7 +48,7 @@ function buildSamlResponse(options) {
       }
     };
 
-    sig.computeSignature(cannonicalized, { prefix: options.signatureNamespacePrefix });
+    sig.computeSignature(cannonicalized, { prefix: options.signatureNamespacePrefix, location: options.location });
     SAMLResponse = sig.getSignedXml();
   }
 


### PR DESCRIPTION
Added 'location' object to the call to 'sig.computeSignature' this allows specifying the reference and action of the Response signature. Without this the location of the Response signature is always appended to the root node per the defaulting logic in xml-crypto\lib\signed-xml.js