### PR TITLE
Fixed issue with providing confirmation response

### DIFF
--- a/lib/samlp.js
+++ b/lib/samlp.js
@@ -173,6 +173,8 @@ module.exports.auth = function(options) {
 
         var id = samlRequestDom.documentElement.getAttribute('ID');
         if (id) opts.inResponseTo = opts.inResponseTo || id;
+        var consumerServiceUrl = samlRequestDom.documentElement.getAttribute('AssertionConsumerServiceURL');
+        if (consumerServiceUrl) opts.recipient = consumerServiceUrl;
       }
 
       opts.getPostURL(audience, samlRequestDom, req, function (err, postUrl) {


### PR DESCRIPTION
Currently the SubjectConfirmation does not provide ResponseTo, but some systems require this to be present in the presence of a provided assertion url.