### PR TITLE
Change xmldom dependency from master to release tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - 4.4.7
+  - 4.8.5
   - 6.9.2
 before_install:
   - npm i -g npm@latest

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "samlp",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "description": "SAML Protocol server middleware",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "saml": "^0.12.1",
     "thumbprint": "0.0.1",
     "xml-crypto": "^0.10.1",
-    "xmldom": "https://github.com/auth0/xmldom/tarball/master",
+    "xmldom": "auth0/xmldom#v0.1.19-auth0_1",
     "xpath": "0.0.5",
     "xtend": "^1.0.3"
   },


### PR DESCRIPTION
Changes the `xmldom` dependency reference from pointing at `auth0/xmldom#master` to a release tag. This is intended to prevent PRs merged to `auth0/xmldom#master` from breaking the yarn.lock consistency checks for dependent projects.

Updates the version to 3.3.3 in preparation of a publish of a new release.