### PR TITLE
Factoring out direct prototype reference of profileMapper

### DIFF
--- a/lib/claims/PassportProfileMapper.js
+++ b/lib/claims/PassportProfileMapper.js
@@ -17,10 +17,10 @@ var fm = {
  *
  * Passport Profile:
  * http://passportjs.org/guide/profile/
- * 
+ *
  * Claim Types:
  * http://msdn.microsoft.com/en-us/library/microsoft.identitymodel.claims.claimtypes_members.aspx
- * 
+ *
  * @param  {Object} pu Passport.js user profile
  */
 function PassportProfileMapper (pu) {
@@ -32,7 +32,7 @@ function PassportProfileMapper (pu) {
 
 /**
  * map passport.js user profile to a wsfed claims based identity.
- * 
+ *
  * @return {Object}    WsFederation claim identity
  */
 PassportProfileMapper.prototype.getClaims = function () {
@@ -43,7 +43,7 @@ PassportProfileMapper.prototype.getClaims = function () {
   claims[fm.name]       = this._pu.displayName;
   claims[fm.givenname]  = this._pu.name.givenName;
   claims[fm.surname]    = this._pu.name.familyName;
-  
+
   var dontRemapAttributes = ['emails', 'displayName', 'name', 'id', '_json'];
 
   Object.keys(this._pu).filter(function (k) {
@@ -57,7 +57,7 @@ PassportProfileMapper.prototype.getClaims = function () {
 
 /**
  * returns the nameidentifier for the saml token.
- * 
+ *
  * @return {Object} object containing a nameIdentifier property and optional nameIdentifierFormat.
  */
 PassportProfileMapper.prototype.getNameIdentifier = function () {
@@ -73,11 +73,27 @@ PassportProfileMapper.prototype.getNameIdentifier = function () {
 
 /**
  * claims metadata used in the metadata endpoint.
- * 
- * @param  {Object} pu Passport.js profile
- * @return {[type]}    WsFederation claim identity
+ *
+ * The metadata property can either be defined as a static property of the ProfileMapper class:
+ *
+ *   ProfileMapper.metadata = [{id: ...}, {...}];
+ *
+ * or on the ProfileMapper instance:
+ *
+ *   function ProfileMapper(user) {
+ *     this.metadata = [{id: ...}, {...}];
+ *   }
+ *
+ * Alternatively, the metadata property can be defined as a function that takes a request as a parameter and returns a metadata object:
+ *
+ *   ProfileMapper.metadata = function getMetadata(req) {
+ *     if (req.params.idp === 'foo-idp') {
+ *       return [{id: ...}, {...}];
+ *     }
+ *     return [{id: ...}, {...}];
+ *   }
  */
-PassportProfileMapper.prototype.metadata = [ {
+PassportProfileMapper.metadata = [ {
   id: "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress",
   optional: true,
   displayName: 'E-Mail Address',

--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -28,6 +28,7 @@ function getEndpointAddress (req, endpointPath) {
  * - issuer string
  * - cert the public certificate
  * - profileMapper a function that given a user returns a claim based identity, also contains the metadata. By default maps from Passport.js user schema (PassportProfile).
+ * - getUserFromRequest optional a function that given a request returns the user. By default req.user
  * - redirectEndpointPath optional, location value for HTTP-Redirect binding (SingleSignOnService)
  * - postEndpointPath optional, location value for HTTP-POST binding (SingleSignOnService)
  * - logoutEndpointPaths.redirect optional, location value for HTTP-Redirect binding (SingleLogoutService)
@@ -47,11 +48,14 @@ function metadataMiddleware (options) {
     throw new Error('options.cert is required');
   }
 
-  var claimTypes = (options.profileMapper || PassportProfileMapper).prototype.metadata;
   var issuer = options.issuer;
   var pem = encoders.removeHeaders(options.cert);
 
   return function (req, res) {
+    var user = options.getUserFromRequest ? options.getUserFromRequest(req) : req.user;
+    var profileMapper = (options.profileMapper || PassportProfileMapper);
+    var metadata = profileMapper.metadata || profileMapper(user).metadata;
+    var claimTypes = typeof metadata === 'function' ? metadata(req) : metadata;
     var redirectEndpoint = getEndpointAddress(req, options.redirectEndpointPath);
     var postEndpoint = getEndpointAddress(req, options.postEndpointPath);
 


### PR DESCRIPTION
Accessing `options.profileMapper.prototype.metadata` as a static breaks the primary benefit of defining `profileMapper` as a class, reusability. This change allows for greater flexibility by allowing the `metadata` property to be defined either as a static property or an instance property of the `profileMapper` class.

This change also allows the `metadata` property to be defined as a function that returns a unique set of metadata based on the request url. This allows for a single IDP instance to vary it's metadata based on the request. This could be query params, base url, or anything else desired.