### PR TITLE
Fix for session participants

### DIFF
--- a/lib/logout.js
+++ b/lib/logout.js
@@ -16,7 +16,7 @@ var STATUS = constants.STATUS;
 
 // Analyze if we should merge session handler and store
 module.exports.logout = function (options) {
-  options.sessionParticipants = options.sessionParticipants || new SessionParticipants();
+  options.sessionParticipants = new SessionParticipants(options.sessionParticipants) || new SessionParticipants();
   options.clearIdPSession = options.clearIdPSession || function (cb){ return cb(); };
   options.store = options.store || new SessionStore({ key: '_logoutState'});
 


### PR DESCRIPTION
The internal SessionParticipants is not exposed, so we should assume they are sending us an array of session participants rather than an instance of the SessionParticipants. If we send an array, currently we get an error similar to "options.sessionParticipants.get is not a function" because it's an array instead of the unexposed SessionParticipants.