### PR TITLE
Use xml-crypto@1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "flowstate": "^0.4.0",
     "querystring": "^0.2.0",
     "saml": "^0.12.1",
-    "xml-crypto": "^0.10.1",
+    "xml-crypto": "^1.0.0",
     "xmldom": "auth0/xmldom#v0.1.19-auth0_1",
     "xpath": "0.0.5",
     "xtend": "^1.0.3"


### PR DESCRIPTION
A new release of xml-crypto was made, delivering several bugfixes (notably now allowing double-signing of responses). Despite the major version change, API and behaviour should remain largely the same

Fixes #69 