### PR TITLE
Use xml-crypto@1.1.4, saml@0.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "ejs": "2.5.5",
     "flowstate": "^0.4.0",
     "querystring": "^0.2.0",
-    "saml": "^0.12.1",
-    "xml-crypto": "^0.10.1",
+    "saml": "^0.13.0",
+    "xml-crypto": "^1.0.2",
     "xmldom": "auth0/xmldom#v0.1.19-auth0_1",
     "xpath": "0.0.5",
     "xtend": "^1.0.3"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "flowstate": "^0.4.0",
     "querystring": "^0.2.0",
     "saml": "^0.13.0",
-    "xml-crypto": "^1.0.2",
+    "xml-crypto": "^1.1.4",
     "xmldom": "auth0/xmldom#v0.1.19-auth0_1",
     "xpath": "0.0.5",
     "xtend": "^1.0.3"

--- a/test/samlp.signedresponse.tests.js
+++ b/test/samlp.signedresponse.tests.js
@@ -18,7 +18,7 @@ describe('samlp signed response', function () {
   });
 
   describe('SAMLRequest on querystring', function () {
-    var body, $, signedResponse, attributes;
+    var body, $, signedResponse, signedAssertion;
 
     before(function (done) {
       request.get({
@@ -31,6 +31,7 @@ describe('samlp signed response', function () {
         var SAMLResponse = $('input[name="SAMLResponse"]').attr('value');
         var decoded = new Buffer(SAMLResponse, 'base64').toString();
         signedResponse = /(<samlp:Response.*<\/samlp:Response>)/.exec(decoded)[1];
+        signedAssertion = /(<saml:Assertion.*<\/saml:Assertion>)/.exec(decoded)[1];
         done();
       });
     });
@@ -41,6 +42,13 @@ describe('samlp signed response', function () {
                 server.credentials.cert);
       expect(isValid).to.be.ok;
     });
+
+    it('should contain a valid signed assertion', function() {
+      var isValid = xmlhelper.verifySignature(
+                signedAssertion,
+                server.credentials.cert);
+      expect(isValid).to.be.ok;
+    })
 
     it('should use sha256 as default signature algorithm', function(){
       var algorithm = xmlhelper.getSignatureMethodAlgorithm(signedResponse);


### PR DESCRIPTION
A new release of xml-crypto was made, delivering several bugfixes (notably now allowing double-signing of responses). Despite the major version change, API and behaviour should remain largely the same

Fixes #69 