### PR TITLE
Add milliseconds to SLO IssueInstant

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ node_js:
   - 4.8.5
   - 6.9.2
 before_install:
-  - npm i -g npm@latest
+  - npm i -g npm@5

--- a/lib/logout.js
+++ b/lib/logout.js
@@ -34,7 +34,7 @@ module.exports.logout = function (options) {
         // Use session to generate SAML Request
         var logoutRequest = templates.logoutrequest({
           ID: utils.generateUniqueID(),
-          IssueInstant: utils.getRoundTripDateFormat(),
+          IssueInstant: utils.generateInstant(),
           Issuer: options.issuer, // IdP identifier
           NameID: { value: participant.nameId, Format: participant.nameIdFormat },
           SessionIndex: participant.sessionIndex,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -158,7 +158,8 @@ module.exports.getRoundTripDateFormat = function() {
         ('0' + date.getUTCDate()).slice(-2) + 'T' +
         ('0' + date.getUTCHours()).slice(-2) + ":" +
         ('0' + date.getUTCMinutes()).slice(-2) + ":" +
-        ('0' + date.getUTCSeconds()).slice(-2) + "Z";
+        ('0' + date.getUTCSeconds()).slice(-2) + "." +
+        ('0' + date.getUTCMilliseconds()).slice(-3) + "Z";
 };
 
 module.exports.validateSignature = validateSignature;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -138,9 +138,35 @@ module.exports.generateUniqueID = function() {
   return uniqueID;
 };
 
+/**
+ * @return {string} the current date/time in `xs:DateTime` format, with millisecond precision.
+ */
 module.exports.generateInstant = function(){
-  var date = new Date();
-  return date.getUTCFullYear() + '-' + ('0' + (date.getUTCMonth()+1)).slice(-2) + '-' + ('0' + date.getUTCDate()).slice(-2) + 'T' + ('0' + date.getUTCHours()).slice(-2) + ":" + ('0' + date.getUTCMinutes()).slice(-2) + ":" + ('0' + date.getUTCSeconds()).slice(-2) + "Z";
+  return module.exports.formatXmlDateTime(new Date());
+};
+
+/**
+ * Formats the given date in `xs:DateTime` format as per Core SAML "1.3.3 Time Values".
+ *
+ * > All SAML time values have the type xs:dateTime, which is built in to the W3C XML Schema Datatypes
+ * > specification [Schema2], and MUST be expressed in UTC form, with no time zone component.
+ * > SAML system entities SHOULD NOT rely on time resolution finer than milliseconds. Implementations
+ * > MUST NOT generate time instants that specify leap seconds.
+ *
+ * @see https://www.w3.org/TR/xmlschema-2/#dateTime
+ * @see https://www.oasis-open.org/committees/download.php/35711/sstc-saml-core-errata-2.0-wd-06-diff.pdf
+ *
+ * @param {Date} date the date to format
+ * @return {string} the formated date/time in `xs:DateTime` format, with millisecond precision.
+ */
+module.exports.formatXmlDateTime = function (date) {
+  return date.getUTCFullYear() + '-' +
+    ('0' + (date.getUTCMonth() + 1)).slice(-2) + '-' +
+    ('0' + date.getUTCDate()).slice(-2) + 'T' +
+    ('0' + date.getUTCHours()).slice(-2) + ":" +
+    ('0' + date.getUTCMinutes()).slice(-2) + ":" +
+    ('0' + date.getUTCSeconds()).slice(-2) + "." +
+    ('00' + date.getUTCMilliseconds()).slice(-3) + "Z";
 };
 
 module.exports.appendQueryString = function(initialUrl, query) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -51,7 +51,7 @@ module.exports.parseSamlRequest = function(req, samlRequest, type, options, call
       issuer = issuerNode[0].textContent;
     }
 
-    // If LogoutRequest, we should check sessionIndex too    
+    // If LogoutRequest, we should check sessionIndex too
     if (constants.ELEMENTS[type].SESSION_INDEX_PATH){
       var sessionIndexNode = xpath.select(constants.ELEMENTS[type].SESSION_INDEX_PATH, xml);
       if (sessionIndexNode && sessionIndexNode.length > 0) {
@@ -59,7 +59,7 @@ module.exports.parseSamlRequest = function(req, samlRequest, type, options, call
       }
     }
 
-    // If LogoutRequest, we should check sessionIndex too    
+    // If LogoutRequest, we should check sessionIndex too
     if (constants.ELEMENTS[type].NAME_ID){
       var nameIdNode = xpath.select(constants.ELEMENTS[type].NAME_ID, xml);
       if (nameIdNode && nameIdNode.length > 0) {
@@ -108,7 +108,7 @@ module.exports.parseSamlRequest = function(req, samlRequest, type, options, call
       try{
         var xml = new xmldom.DOMParser().parseFromString(buffer.toString());
       }
-      catch(e) { 
+      catch(e) {
         return callback(new Error(e));
       }
 
@@ -174,18 +174,6 @@ module.exports.appendQueryString = function(initialUrl, query) {
   parsed.query = xtend(parsed.query, query);
   delete parsed.search;
   return url.format(parsed);
-};
-
-module.exports.getRoundTripDateFormat = function() {
-  //http://msdn.microsoft.com/en-us/library/az4se3k1.aspx#Roundtrip
-  var date = new Date();
-  return date.getUTCFullYear() + '-' +
-        ('0' + (date.getUTCMonth()+1)).slice(-2) + '-' +
-        ('0' + date.getUTCDate()).slice(-2) + 'T' +
-        ('0' + date.getUTCHours()).slice(-2) + ":" +
-        ('0' + date.getUTCMinutes()).slice(-2) + ":" +
-        ('0' + date.getUTCSeconds()).slice(-2) + "." +
-        ('0' + date.getUTCMilliseconds()).slice(-3) + "Z";
 };
 
 module.exports.validateSignature = validateSignature;

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "flowstate": "^0.4.0",
     "querystring": "^0.2.0",
     "saml": "^0.12.1",
+    "timekeeper": "^2.2.0",
     "xml-crypto": "^0.10.1",
     "xmldom": "auth0/xmldom#v0.1.19-auth0_1",
     "xpath": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "flowstate": "^0.4.0",
     "querystring": "^0.2.0",
     "saml": "^0.12.1",
-    "timekeeper": "^2.2.0",
     "xml-crypto": "^0.10.1",
     "xmldom": "auth0/xmldom#v0.1.19-auth0_1",
     "xpath": "0.0.5",
@@ -39,6 +38,7 @@
     "istanbul": "^0.4.5",
     "mocha": "~1.8.1",
     "request": "~2.14.0",
+    "timekeeper": "^2.2.0",
     "uid2": "0.0.3"
   }
 }

--- a/test/samlp.logout.custom_store.tests.js
+++ b/test/samlp.logout.custom_store.tests.js
@@ -49,14 +49,14 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
 
   var frozenTime;
   before(() => {
-    frozenTime = new Date(Date.now());
-    timekeeper.freeze(frozenTime)
+    frozenTime = Date.now();
+    timekeeper.freeze(frozenTime);
   });
 
   after(() => timekeeper.reset());
 
   before(function (done) {
-    server.start( { 
+    server.start( {
       audience: 'https://auth0-dev-ed.my.salesforce.com',
       issuer: samlIdPIssuer,
       store: testStore,
@@ -78,7 +78,7 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
 
   beforeEach(function (done) {
     request.get({
-      jar: request.jar(), 
+      jar: request.jar(),
       uri: 'http://localhost:5050/samlp?SAMLRequest=fZJbc6owFIX%2FCpN3EAEVMmIHEfDaqlCP%2BtKJELkUEkqCl%2F76Uj3O9JyHPmay9l4r%2BVb%2F6VLkwglXLKXEBG1JBgImIY1SEpvgNXBFHTwN%2BgwVeQmtmidkjT9qzLjQzBEGbxcmqCsCKWIpgwQVmEEeQt9azKEiybCsKKchzYFgMYYr3hjZlLC6wJWPq1Ma4tf13AQJ5yWDrVZO45RIDOWYHWkVYimkBRBGjWVKEL%2BlfEhDSjhlVEJNLvlb1%2FqOA4TJyARvynPH80qFFJPAdg%2Fh1fNnGVqpKO3OLkZonUfJ0Nu2Y2t6PdlVPj1RZxVlThywI8rihVH0MuksTQz3sx1Fm2xv5LO9nYSs5KXxfnm364%2FwfMDPWMqn182qHOqpjzR0dncsM6xO1Vs7h860HI97yrB7xHE9dt2loy%2FQu1prie%2FMcuNNL2i6nUdWp%2Fdnk3yekb7dXYhWjFjil%2Br2IC%2Bd%2FexlNF7wS77Zomvo7epFbCuyVx5tq3klYzWeEMYR4SZQ5LYqypqo6IGiQE2FmiKpencPhOXf%2Fx%2Bm5E71N1iHu4jBcRAsxeWLHwBh82hHIwD3LsCbefWjBL%2BvRQ%2FyYPCAd4MmRvgk4kgqrv8R77d%2B2Azup38LOPgC&RelayState=123'
     }, function (err, response, b){
       if(err) return done(err);
@@ -171,7 +171,7 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
           var query = qs.parse(response.headers.location.substr(i));
           var SAMLResponse = query.SAMLResponse;
           RelayState = query.RelayState;
-          
+
           zlib.inflateRaw(new Buffer(SAMLResponse, 'base64'), function (err, decodedAndInflated) {
             if(err) return done(err);
             signedAssertion = /(<samlp:StatusCode.*\/>)/.exec(decodedAndInflated)[1];
@@ -249,8 +249,7 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
 
       it('should validate LogoutRequest to Session Participant', function () {
         expect(sessionParticipantLogoutRequest).to.exist;
-        expect(xmlhelper.getIssueInstant(sessionParticipantLogoutRequest)).to.exist;
-        expect(new Date(xmlhelper.getIssueInstant(sessionParticipantLogoutRequest)).getTime()).to.equal(frozenTime.getTime());
+        expect(xmlhelper.getIssueInstantUTC(sessionParticipantLogoutRequest)).to.equal(frozenTime);
         expect(xmlhelper.getDestination(sessionParticipantLogoutRequest)).to.equal(sessionParticipant2.serviceProviderLogoutURL);
         expect(xmlhelper.getConsent(sessionParticipantLogoutRequest)).to.equal('urn:oasis:names:tc:SAML:2.0:consent:unspecified');
         expect(xmlhelper.getElementText(sessionParticipantLogoutRequest, 'Issuer')).to.equal(samlIdPIssuer);
@@ -271,7 +270,7 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
             SigAlg: sessionParticipantLogoutRequestSigAlg,
             Signature: sessionParticipantLogoutRequestSignature
           }
-        }; 
+        };
 
         expect(utils.validateSignature(params, "LOGOUT_REQUEST", sessionParticipantLogoutRequest, { signingCert: server.credentials.cert.toString(), deflate: true })).to.be.undefined;
       });
@@ -287,7 +286,7 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
           // SAMLResponse: base64 encoded + deflated + URLEncoded
           // Signature: URLEncoded
           // SigAlg: URLEncoded
-          // 
+          //
           // <samlp:LogoutResponse xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
           //   ID="_2bba6ea5e677d807f06a"
           //   InResponseTo="samlr-220c705e-c15e-11e6-98a4-ecf4bbce4318"
@@ -306,7 +305,7 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
             SigAlg: 'http://www.w3.org/2000/09/xmldsig#rsa-sha1',
           };
 
-          // We need to sign the reponse here          
+          // We need to sign the reponse here
           var signature = signers.sign({key: sp2_credentials.key, signatureAlgorithm: 'rsa-sha1' }, qs.stringify(params));
           params.Signature = signature;
 
@@ -339,9 +338,8 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
 
         it('should validate LogoutResponse to the Session Participant that initiated the logout', function () {
           expect(sessionParticipantLogoutResponse).to.exist;
-          expect(xmlhelper.getIssueInstant(sessionParticipantLogoutResponse)).to.exist;
-          expect(new Date(xmlhelper.getIssueInstant(sessionParticipantLogoutRequest)).getTime()).to.equal(frozenTime.getTime());
-          expect(xmlhelper.getDestination(sessionParticipantLogoutResponse)).to.equal(sessionParticipant1.serviceProviderLogoutURL); 
+          expect(xmlhelper.getIssueInstantUTC(sessionParticipantLogoutRequest)).to.equal(frozenTime);
+          expect(xmlhelper.getDestination(sessionParticipantLogoutResponse)).to.equal(sessionParticipant1.serviceProviderLogoutURL);
           expect(xmlhelper.getInResponseTo(sessionParticipantLogoutResponse)).to.equal('samlr-220c705e-c15e-11e6-98a4-ecf4bbce4318');
           expect(xmlhelper.getIssuer(sessionParticipantLogoutResponse)).to.equal(samlIdPIssuer);
         });
@@ -368,7 +366,7 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
             }
           };
 
-          expect(utils.validateSignature(params, "LOGOUT_RESPONSE", sessionParticipantLogoutResponse, { signingCert: server.credentials.cert.toString(), deflate: true })).to.be.undefined;        
+          expect(utils.validateSignature(params, "LOGOUT_RESPONSE", sessionParticipantLogoutResponse, { signingCert: server.credentials.cert.toString(), deflate: true })).to.be.undefined;
         });
 
         it('should remove session from sessions array', function () {
@@ -486,8 +484,7 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
 
       it('should validate LogoutRequest to Session Participant', function () {
         expect(sessionParticipantLogoutRequest).to.exist;
-        expect(xmlhelper.getIssueInstant(sessionParticipantLogoutRequest)).to.exist;
-        expect(new Date(xmlhelper.getIssueInstant(sessionParticipantLogoutRequest)).getTime()).to.equal(frozenTime.getTime());
+        expect(xmlhelper.getIssueInstantUTC(sessionParticipantLogoutRequest)).to.equal(frozenTime);
         expect(xmlhelper.getDestination(sessionParticipantLogoutRequest)).to.equal(sessionParticipant1.serviceProviderLogoutURL);
         expect(xmlhelper.getConsent(sessionParticipantLogoutRequest)).to.equal('urn:oasis:names:tc:SAML:2.0:consent:unspecified');
         expect(xmlhelper.getElementText(sessionParticipantLogoutRequest, 'Issuer')).to.equal(samlIdPIssuer);
@@ -508,7 +505,7 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
             SigAlg: sessionParticipantLogoutRequestSigAlg,
             Signature: sessionParticipantLogoutRequestSignature
           }
-        }; 
+        };
 
         expect(utils.validateSignature(params, "LOGOUT_REQUEST", sessionParticipantLogoutRequest, { signingCert: server.credentials.cert.toString(), deflate: true })).to.be.undefined;
       });
@@ -536,7 +533,7 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
           uri: 'http://localhost:5050/logout'
         }, function (err, response) {
           if(err) return done(err);
-          
+
           expect(response.statusCode).to.equal(302);
 
           var i = response.headers.location.indexOf('?');
@@ -559,8 +556,7 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
 
       it('should validate LogoutRequest to Session Participant', function () {
         expect(sessionParticipantLogoutRequest).to.exist;
-        expect(xmlhelper.getIssueInstant(sessionParticipantLogoutRequest)).to.exist;
-        expect(new Date(xmlhelper.getIssueInstant(sessionParticipantLogoutRequest)).getTime()).to.equal(frozenTime.getTime());
+        expect(xmlhelper.getIssueInstantUTC(sessionParticipantLogoutRequest)).to.equal(frozenTime);
         expect(xmlhelper.getDestination(sessionParticipantLogoutRequest)).to.equal(sessionParticipant1.serviceProviderLogoutURL);
         expect(xmlhelper.getConsent(sessionParticipantLogoutRequest)).to.equal('urn:oasis:names:tc:SAML:2.0:consent:unspecified');
         expect(xmlhelper.getElementText(sessionParticipantLogoutRequest, 'Issuer')).to.equal(samlIdPIssuer);
@@ -582,7 +578,7 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
             SigAlg: sessionParticipantLogoutRequestSigAlg,
             Signature: sessionParticipantLogoutRequestSignature
           }
-        }; 
+        };
 
         expect(utils.validateSignature(params, "LOGOUT_REQUEST", sessionParticipantLogoutRequest, { signingCert: server.credentials.cert.toString(), deflate: true })).to.be.undefined;
       });
@@ -598,7 +594,7 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
           // SAMLResponse: base64 encoded + deflated + URLEncoded
           // Signature: URLEncoded
           // SigAlg: URLEncoded
-          // 
+          //
           // <samlp:LogoutResponse xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
           //   ID="_2bba6ea5e677d807f06a"
           //   InResponseTo="_73dda80c6c1262377f52"
@@ -650,8 +646,7 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
 
         it('should validate LogoutRequest to Session Participant 2', function () {
           expect(sessionParticipant2LogoutRequest).to.exist;
-          expect(xmlhelper.getIssueInstant(sessionParticipant2LogoutRequest)).to.exist;
-          expect(new Date(xmlhelper.getIssueInstant(sessionParticipantLogoutRequest)).getTime()).to.equal(frozenTime.getTime());
+          expect(xmlhelper.getIssueInstantUTC(sessionParticipant2LogoutRequest)).to.equal(frozenTime);
           expect(xmlhelper.getDestination(sessionParticipant2LogoutRequest)).to.equal(sessionParticipant2.serviceProviderLogoutURL);
           expect(xmlhelper.getConsent(sessionParticipant2LogoutRequest)).to.equal('urn:oasis:names:tc:SAML:2.0:consent:unspecified');
           expect(xmlhelper.getElementText(sessionParticipant2LogoutRequest, 'Issuer')).to.equal(samlIdPIssuer);
@@ -671,7 +666,7 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
               SigAlg: sessionParticipant2LogoutRequestSigAlg,
               Signature: sessionParticipant2LogoutRequestSignature
             }
-          }; 
+          };
 
           expect(utils.validateSignature(params, "LOGOUT_REQUEST", sessionParticipant2LogoutRequest, { signingCert: server.credentials.cert.toString(), deflate: true })).to.be.undefined;
         });
@@ -757,7 +752,7 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
           expect(response.statusCode).to.equal(200);
           $ = cheerio.load(response.body);
           var SAMLResponse = $('input[name="SAMLResponse"]').attr('value');
-          relayState = $('input[name="RelayState"]').attr('value');        
+          relayState = $('input[name="RelayState"]').attr('value');
           samlResponse = new Buffer(SAMLResponse, 'base64');
           signedAssertion = /(<samlp:StatusCode.*\/>)/.exec(samlResponse)[1];
           var doc = new xmldom.DOMParser().parseFromString(signedAssertion);
@@ -823,8 +818,7 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
 
       it('should validate LogoutRequest to Session Participant', function () {
         expect(sessionParticipantLogoutRequest).to.exist;
-        expect(xmlhelper.getIssueInstant(sessionParticipantLogoutRequest)).to.exist;
-        expect(new Date(xmlhelper.getIssueInstant(sessionParticipantLogoutRequest)).getTime()).to.equal(frozenTime.getTime());
+        expect(xmlhelper.getIssueInstantUTC(sessionParticipantLogoutRequest)).to.equal(frozenTime);
         expect(xmlhelper.getDestination(sessionParticipantLogoutRequest)).to.equal(sessionParticipant2.serviceProviderLogoutURL);
         expect(xmlhelper.getConsent(sessionParticipantLogoutRequest)).to.equal('urn:oasis:names:tc:SAML:2.0:consent:unspecified');
         expect(xmlhelper.getElementText(sessionParticipantLogoutRequest, 'Issuer')).to.equal(samlIdPIssuer);
@@ -838,7 +832,7 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
         expect(sessionParticipantLogoutRequestRelayState).to.exist;
 
         // TODO: Review as we need to merge validation methods
-        var doc = new xmldom.DOMParser().parseFromString(sessionParticipantLogoutRequest);        
+        var doc = new xmldom.DOMParser().parseFromString(sessionParticipantLogoutRequest);
         expect(utils.validateSignature({body : { SAMLRequest: SAMLRequest }}, "LOGOUT_REQUEST", doc, { signingCert: server.credentials.cert })).to.be.undefined;
       });
 
@@ -871,7 +865,7 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
             if (err) { return done(err); }
             $ = cheerio.load(response.body);
             SAMLResponse = $('input[name="SAMLResponse"]').attr('value');
-            sessionParticipantLogoutResponseRelayState = $('input[name="RelayState"]').attr('value');        
+            sessionParticipantLogoutResponseRelayState = $('input[name="RelayState"]').attr('value');
             sessionParticipantLogoutResponse = new Buffer(SAMLResponse, 'base64').toString();
             done();
           });
@@ -879,9 +873,8 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
 
         it('should validate LogoutResponse to the Session Participant that initiated the logout', function () {
           expect(sessionParticipantLogoutResponse).to.exist;
-          expect(xmlhelper.getIssueInstant(sessionParticipantLogoutResponse)).to.exist;
-          expect(new Date(xmlhelper.getIssueInstant(sessionParticipantLogoutRequest)).getTime()).to.equal(frozenTime.getTime());
-          expect(xmlhelper.getDestination(sessionParticipantLogoutResponse)).to.equal(sessionParticipant1.serviceProviderLogoutURL); 
+          expect(xmlhelper.getIssueInstantUTC(sessionParticipantLogoutRequest)).to.equal(frozenTime);
+          expect(xmlhelper.getDestination(sessionParticipantLogoutResponse)).to.equal(sessionParticipant1.serviceProviderLogoutURL);
           expect(xmlhelper.getInResponseTo(sessionParticipantLogoutResponse)).to.equal('pfx6fe657e3-1a7f-893e-f690-f7fc5162ea11');
           expect(xmlhelper.getIssuer(sessionParticipantLogoutResponse)).to.equal(samlIdPIssuer);
         });
@@ -896,9 +889,9 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
         it('should validate LogoutResponse signature', function () {
           expect(SAMLResponse).to.exist;
           expect(sessionParticipantLogoutResponseRelayState).to.exist;
-          
-          // TODO: Review as we need to merge validation methods          
-          var doc = new xmldom.DOMParser().parseFromString(sessionParticipantLogoutResponse);                  
+
+          // TODO: Review as we need to merge validation methods
+          var doc = new xmldom.DOMParser().parseFromString(sessionParticipantLogoutResponse);
           expect(utils.validateSignature({body : { SAMLResponse: SAMLResponse }}, "LOGOUT_RESPONSE", doc, { signingCert: server.credentials.cert })).to.be.undefined;
         });
 
@@ -918,7 +911,7 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
         sessions.push({
           serviceProviderId : 'an-issuer',
           nameId: 'foo@example.com',
-          nameIdFormat: 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient',          
+          nameIdFormat: 'urn:oasis:names:tc:SAML:2.0:nameid-format:transient',
           sessionIndex: '1',
           serviceProviderLogoutURL: 'https://example.com/logout',
           cert: sp1_credentials.cert
@@ -945,8 +938,8 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
           expect(response.statusCode).to.equal(200);
           $ = cheerio.load(response.body);
           var SAMLResponse = $('input[name="SAMLResponse"]').attr('value');
-          relayState = $('input[name="RelayState"]').attr('value'); 
-          action = $('form').attr('action');                         
+          relayState = $('input[name="RelayState"]').attr('value');
+          action = $('form').attr('action');
           samlResponse = new Buffer(SAMLResponse, 'base64');
           signedAssertion = /(<samlp:StatusCode.*\/>)/.exec(samlResponse)[1];
           var doc = new xmldom.DOMParser().parseFromString(signedAssertion);
@@ -1034,7 +1027,7 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
             expect(response.statusCode).to.equal(200);
             $ = cheerio.load(response.body);
             SAMLResponse = $('input[name="SAMLResponse"]').attr('value');
-            sessionParticipantLogoutResponseRelayState = $('input[name="RelayState"]').attr('value');        
+            sessionParticipantLogoutResponseRelayState = $('input[name="RelayState"]').attr('value');
             sessionParticipantLogoutResponse = new Buffer(SAMLResponse, 'base64').toString();
             done();
           });
@@ -1111,7 +1104,7 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
 
       describe('should send Session Participant LogoutResponse to the SAML IdP', function () {
         var SAMLResponse;
-      
+
         before(function (done) {
           // <samlp:LogoutResponse xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
           //   ID="_2bba6ea5e677d807f06a"

--- a/test/samlp.logout.custom_store.tests.js
+++ b/test/samlp.logout.custom_store.tests.js
@@ -12,6 +12,7 @@ var InMemoryStore = require('./in_memory_store');
 var SPs           = require('../lib/sessionParticipants');
 var fs            = require('fs');
 var path          = require('path');
+const timekeeper  = require('timekeeper');
 
 var sp1_credentials = {
   cert:     fs.readFileSync(path.join(__dirname, 'fixture', 'sp1.pem')),
@@ -45,6 +46,14 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
   var sessions = [], returnError;
   var samlIdPIssuer = 'urn:fixture-test';
   var testStore = new InMemoryStore();
+
+  let frozenTime;
+  before(() => {
+    frozenTime = new Date(Date.now());
+    timekeeper.freeze(frozenTime)
+  });
+
+  after(() => timekeeper.reset());
 
   before(function (done) {
     server.start( { 
@@ -241,6 +250,7 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
       it('should validate LogoutRequest to Session Participant', function () {
         expect(sessionParticipantLogoutRequest).to.exist;
         expect(xmlhelper.getIssueInstant(sessionParticipantLogoutRequest)).to.exist;
+        expect(new Date(xmlhelper.getIssueInstant(sessionParticipantLogoutRequest)).getTime()).to.equal(frozenTime.getTime());
         expect(xmlhelper.getDestination(sessionParticipantLogoutRequest)).to.equal(sessionParticipant2.serviceProviderLogoutURL);
         expect(xmlhelper.getConsent(sessionParticipantLogoutRequest)).to.equal('urn:oasis:names:tc:SAML:2.0:consent:unspecified');
         expect(xmlhelper.getElementText(sessionParticipantLogoutRequest, 'Issuer')).to.equal(samlIdPIssuer);
@@ -330,6 +340,7 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
         it('should validate LogoutResponse to the Session Participant that initiated the logout', function () {
           expect(sessionParticipantLogoutResponse).to.exist;
           expect(xmlhelper.getIssueInstant(sessionParticipantLogoutResponse)).to.exist;
+          expect(new Date(xmlhelper.getIssueInstant(sessionParticipantLogoutRequest)).getTime()).to.equal(frozenTime.getTime());
           expect(xmlhelper.getDestination(sessionParticipantLogoutResponse)).to.equal(sessionParticipant1.serviceProviderLogoutURL); 
           expect(xmlhelper.getInResponseTo(sessionParticipantLogoutResponse)).to.equal('samlr-220c705e-c15e-11e6-98a4-ecf4bbce4318');
           expect(xmlhelper.getIssuer(sessionParticipantLogoutResponse)).to.equal(samlIdPIssuer);
@@ -476,6 +487,7 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
       it('should validate LogoutRequest to Session Participant', function () {
         expect(sessionParticipantLogoutRequest).to.exist;
         expect(xmlhelper.getIssueInstant(sessionParticipantLogoutRequest)).to.exist;
+        expect(new Date(xmlhelper.getIssueInstant(sessionParticipantLogoutRequest)).getTime()).to.equal(frozenTime.getTime());
         expect(xmlhelper.getDestination(sessionParticipantLogoutRequest)).to.equal(sessionParticipant1.serviceProviderLogoutURL);
         expect(xmlhelper.getConsent(sessionParticipantLogoutRequest)).to.equal('urn:oasis:names:tc:SAML:2.0:consent:unspecified');
         expect(xmlhelper.getElementText(sessionParticipantLogoutRequest, 'Issuer')).to.equal(samlIdPIssuer);
@@ -548,6 +560,7 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
       it('should validate LogoutRequest to Session Participant', function () {
         expect(sessionParticipantLogoutRequest).to.exist;
         expect(xmlhelper.getIssueInstant(sessionParticipantLogoutRequest)).to.exist;
+        expect(new Date(xmlhelper.getIssueInstant(sessionParticipantLogoutRequest)).getTime()).to.equal(frozenTime.getTime());
         expect(xmlhelper.getDestination(sessionParticipantLogoutRequest)).to.equal(sessionParticipant1.serviceProviderLogoutURL);
         expect(xmlhelper.getConsent(sessionParticipantLogoutRequest)).to.equal('urn:oasis:names:tc:SAML:2.0:consent:unspecified');
         expect(xmlhelper.getElementText(sessionParticipantLogoutRequest, 'Issuer')).to.equal(samlIdPIssuer);
@@ -638,6 +651,7 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
         it('should validate LogoutRequest to Session Participant 2', function () {
           expect(sessionParticipant2LogoutRequest).to.exist;
           expect(xmlhelper.getIssueInstant(sessionParticipant2LogoutRequest)).to.exist;
+          expect(new Date(xmlhelper.getIssueInstant(sessionParticipantLogoutRequest)).getTime()).to.equal(frozenTime.getTime());
           expect(xmlhelper.getDestination(sessionParticipant2LogoutRequest)).to.equal(sessionParticipant2.serviceProviderLogoutURL);
           expect(xmlhelper.getConsent(sessionParticipant2LogoutRequest)).to.equal('urn:oasis:names:tc:SAML:2.0:consent:unspecified');
           expect(xmlhelper.getElementText(sessionParticipant2LogoutRequest, 'Issuer')).to.equal(samlIdPIssuer);
@@ -810,6 +824,7 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
       it('should validate LogoutRequest to Session Participant', function () {
         expect(sessionParticipantLogoutRequest).to.exist;
         expect(xmlhelper.getIssueInstant(sessionParticipantLogoutRequest)).to.exist;
+        expect(new Date(xmlhelper.getIssueInstant(sessionParticipantLogoutRequest)).getTime()).to.equal(frozenTime.getTime());
         expect(xmlhelper.getDestination(sessionParticipantLogoutRequest)).to.equal(sessionParticipant2.serviceProviderLogoutURL);
         expect(xmlhelper.getConsent(sessionParticipantLogoutRequest)).to.equal('urn:oasis:names:tc:SAML:2.0:consent:unspecified');
         expect(xmlhelper.getElementText(sessionParticipantLogoutRequest, 'Issuer')).to.equal(samlIdPIssuer);
@@ -865,6 +880,7 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
         it('should validate LogoutResponse to the Session Participant that initiated the logout', function () {
           expect(sessionParticipantLogoutResponse).to.exist;
           expect(xmlhelper.getIssueInstant(sessionParticipantLogoutResponse)).to.exist;
+          expect(new Date(xmlhelper.getIssueInstant(sessionParticipantLogoutRequest)).getTime()).to.equal(frozenTime.getTime());
           expect(xmlhelper.getDestination(sessionParticipantLogoutResponse)).to.equal(sessionParticipant1.serviceProviderLogoutURL); 
           expect(xmlhelper.getInResponseTo(sessionParticipantLogoutResponse)).to.equal('pfx6fe657e3-1a7f-893e-f690-f7fc5162ea11');
           expect(xmlhelper.getIssuer(sessionParticipantLogoutResponse)).to.equal(samlIdPIssuer);

--- a/test/samlp.logout.custom_store.tests.js
+++ b/test/samlp.logout.custom_store.tests.js
@@ -47,7 +47,7 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
   var samlIdPIssuer = 'urn:fixture-test';
   var testStore = new InMemoryStore();
 
-  let frozenTime;
+  var frozenTime;
   before(() => {
     frozenTime = new Date(Date.now());
     timekeeper.freeze(frozenTime)

--- a/test/samlp.logout.custom_store.tests.js
+++ b/test/samlp.logout.custom_store.tests.js
@@ -338,7 +338,7 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
 
         it('should validate LogoutResponse to the Session Participant that initiated the logout', function () {
           expect(sessionParticipantLogoutResponse).to.exist;
-          expect(xmlhelper.getIssueInstantUTC(sessionParticipantLogoutRequest)).to.equal(frozenTime);
+          expect(xmlhelper.getIssueInstantUTC(sessionParticipantLogoutResponse)).to.equal(frozenTime);
           expect(xmlhelper.getDestination(sessionParticipantLogoutResponse)).to.equal(sessionParticipant1.serviceProviderLogoutURL);
           expect(xmlhelper.getInResponseTo(sessionParticipantLogoutResponse)).to.equal('samlr-220c705e-c15e-11e6-98a4-ecf4bbce4318');
           expect(xmlhelper.getIssuer(sessionParticipantLogoutResponse)).to.equal(samlIdPIssuer);
@@ -873,7 +873,7 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
 
         it('should validate LogoutResponse to the Session Participant that initiated the logout', function () {
           expect(sessionParticipantLogoutResponse).to.exist;
-          expect(xmlhelper.getIssueInstantUTC(sessionParticipantLogoutRequest)).to.equal(frozenTime);
+          expect(xmlhelper.getIssueInstantUTC(sessionParticipantLogoutResponse)).to.equal(frozenTime);
           expect(xmlhelper.getDestination(sessionParticipantLogoutResponse)).to.equal(sessionParticipant1.serviceProviderLogoutURL);
           expect(xmlhelper.getInResponseTo(sessionParticipantLogoutResponse)).to.equal('pfx6fe657e3-1a7f-893e-f690-f7fc5162ea11');
           expect(xmlhelper.getIssuer(sessionParticipantLogoutResponse)).to.equal(samlIdPIssuer);

--- a/test/samlp.logout.session_store.tests.js
+++ b/test/samlp.logout.session_store.tests.js
@@ -45,7 +45,7 @@ describe('samlp logout with Session Participants - Session Provider', function (
   var sessions = [], returnError;
   var samlIdPIssuer = 'urn:fixture-test';
   
-  let frozenTime;
+  var frozenTime;
   before(() => {
     frozenTime = new Date(Date.now());
     timekeeper.freeze(frozenTime)

--- a/test/samlp.logout.session_store.tests.js
+++ b/test/samlp.logout.session_store.tests.js
@@ -11,6 +11,7 @@ var signers       = require('../lib/signers');
 var fs            = require('fs');
 var path          = require('path');
 var SPs           = require('../lib/sessionParticipants');
+const timekeeper  = require('timekeeper');
 
 var sp1_credentials = {
   cert:     fs.readFileSync(path.join(__dirname, 'fixture', 'sp1.pem')),
@@ -44,6 +45,14 @@ describe('samlp logout with Session Participants - Session Provider', function (
   var sessions = [], returnError;
   var samlIdPIssuer = 'urn:fixture-test';
   
+  let frozenTime;
+  before(() => {
+    frozenTime = new Date(Date.now());
+    timekeeper.freeze(frozenTime)
+  });
+
+  after(() => timekeeper.reset());
+
   before(function (done) {
     server.start( { 
       audience: 'https://auth0-dev-ed.my.salesforce.com',
@@ -230,6 +239,7 @@ describe('samlp logout with Session Participants - Session Provider', function (
       it('should validate LogoutRequest to Session Participant', function () {
         expect(sessionParticipantLogoutRequest).to.exist;
         expect(xmlhelper.getIssueInstant(sessionParticipantLogoutRequest)).to.exist;
+        expect(new Date(xmlhelper.getIssueInstant(sessionParticipantLogoutRequest)).getTime()).to.equal(frozenTime.getTime());
         expect(xmlhelper.getDestination(sessionParticipantLogoutRequest)).to.equal(sessionParticipant2.serviceProviderLogoutURL);
         expect(xmlhelper.getConsent(sessionParticipantLogoutRequest)).to.equal('urn:oasis:names:tc:SAML:2.0:consent:unspecified');
         expect(xmlhelper.getElementText(sessionParticipantLogoutRequest, 'Issuer')).to.equal(samlIdPIssuer);
@@ -317,6 +327,7 @@ describe('samlp logout with Session Participants - Session Provider', function (
         it('should validate LogoutResponse to the Session Participant that initiated the logout', function () {
           expect(sessionParticipantLogoutResponse).to.exist;
           expect(xmlhelper.getIssueInstant(sessionParticipantLogoutResponse)).to.exist;
+          expect(new Date(xmlhelper.getIssueInstant(sessionParticipantLogoutRequest)).getTime()).to.equal(frozenTime.getTime());
           expect(xmlhelper.getDestination(sessionParticipantLogoutResponse)).to.equal(sessionParticipant1.serviceProviderLogoutURL); 
           expect(xmlhelper.getInResponseTo(sessionParticipantLogoutResponse)).to.equal('samlr-220c705e-c15e-11e6-98a4-ecf4bbce4318');
           expect(xmlhelper.getIssuer(sessionParticipantLogoutResponse)).to.equal(samlIdPIssuer);
@@ -530,6 +541,7 @@ describe('samlp logout with Session Participants - Session Provider', function (
       it('should validate LogoutRequest to Session Participant', function () {
         expect(sessionParticipantLogoutRequest).to.exist;
         expect(xmlhelper.getIssueInstant(sessionParticipantLogoutRequest)).to.exist;
+        expect(new Date(xmlhelper.getIssueInstant(sessionParticipantLogoutRequest)).getTime()).to.equal(frozenTime.getTime());
         expect(xmlhelper.getDestination(sessionParticipantLogoutRequest)).to.equal(sessionParticipant1.serviceProviderLogoutURL);
         expect(xmlhelper.getConsent(sessionParticipantLogoutRequest)).to.equal('urn:oasis:names:tc:SAML:2.0:consent:unspecified');
         expect(xmlhelper.getElementText(sessionParticipantLogoutRequest, 'Issuer')).to.equal(samlIdPIssuer);
@@ -599,6 +611,7 @@ describe('samlp logout with Session Participants - Session Provider', function (
       it('should validate LogoutRequest to Session Participant', function () {
         expect(sessionParticipantLogoutRequest).to.exist;
         expect(xmlhelper.getIssueInstant(sessionParticipantLogoutRequest)).to.exist;
+        expect(new Date(xmlhelper.getIssueInstant(sessionParticipantLogoutRequest)).getTime()).to.equal(frozenTime.getTime());
         expect(xmlhelper.getDestination(sessionParticipantLogoutRequest)).to.equal(sessionParticipant1.serviceProviderLogoutURL);
         expect(xmlhelper.getConsent(sessionParticipantLogoutRequest)).to.equal('urn:oasis:names:tc:SAML:2.0:consent:unspecified');
         expect(xmlhelper.getElementText(sessionParticipantLogoutRequest, 'Issuer')).to.equal(samlIdPIssuer);
@@ -686,6 +699,7 @@ describe('samlp logout with Session Participants - Session Provider', function (
         it('should validate LogoutRequest to Session Participant 2', function () {
           expect(sessionParticipant2LogoutRequest).to.exist;
           expect(xmlhelper.getIssueInstant(sessionParticipant2LogoutRequest)).to.exist;
+          expect(new Date(xmlhelper.getIssueInstant(sessionParticipantLogoutRequest)).getTime()).to.equal(frozenTime.getTime());
           expect(xmlhelper.getDestination(sessionParticipant2LogoutRequest)).to.equal(sessionParticipant2.serviceProviderLogoutURL);
           expect(xmlhelper.getConsent(sessionParticipant2LogoutRequest)).to.equal('urn:oasis:names:tc:SAML:2.0:consent:unspecified');
           expect(xmlhelper.getElementText(sessionParticipant2LogoutRequest, 'Issuer')).to.equal(samlIdPIssuer);
@@ -849,6 +863,7 @@ describe('samlp logout with Session Participants - Session Provider', function (
       it('should validate LogoutRequest to Session Participant', function () {
         expect(sessionParticipantLogoutRequest).to.exist;
         expect(xmlhelper.getIssueInstant(sessionParticipantLogoutRequest)).to.exist;
+        expect(new Date(xmlhelper.getIssueInstant(sessionParticipantLogoutRequest)).getTime()).to.equal(frozenTime.getTime());
         expect(xmlhelper.getDestination(sessionParticipantLogoutRequest)).to.equal(sessionParticipant2.serviceProviderLogoutURL);
         expect(xmlhelper.getConsent(sessionParticipantLogoutRequest)).to.equal('urn:oasis:names:tc:SAML:2.0:consent:unspecified');
         expect(xmlhelper.getElementText(sessionParticipantLogoutRequest, 'Issuer')).to.equal(samlIdPIssuer);
@@ -903,6 +918,7 @@ describe('samlp logout with Session Participants - Session Provider', function (
         it('should validate LogoutResponse to the Session Participant that initiated the logout', function () {
           expect(sessionParticipantLogoutResponse).to.exist;
           expect(xmlhelper.getIssueInstant(sessionParticipantLogoutResponse)).to.exist;
+          expect(new Date(xmlhelper.getIssueInstant(sessionParticipantLogoutRequest)).getTime()).to.equal(frozenTime.getTime());
           expect(xmlhelper.getDestination(sessionParticipantLogoutResponse)).to.equal(sessionParticipant1.serviceProviderLogoutURL); 
           expect(xmlhelper.getInResponseTo(sessionParticipantLogoutResponse)).to.equal('pfx6fe657e3-1a7f-893e-f690-f7fc5162ea11');
           expect(xmlhelper.getIssuer(sessionParticipantLogoutResponse)).to.equal(samlIdPIssuer);

--- a/test/samlp.logout.session_store.tests.js
+++ b/test/samlp.logout.session_store.tests.js
@@ -47,8 +47,8 @@ describe('samlp logout with Session Participants - Session Provider', function (
   
   var frozenTime;
   before(() => {
-    frozenTime = new Date(Date.now());
-    timekeeper.freeze(frozenTime)
+    frozenTime = Date.now();
+    timekeeper.freeze(frozenTime);
   });
 
   after(() => timekeeper.reset());
@@ -238,8 +238,7 @@ describe('samlp logout with Session Participants - Session Provider', function (
 
       it('should validate LogoutRequest to Session Participant', function () {
         expect(sessionParticipantLogoutRequest).to.exist;
-        expect(xmlhelper.getIssueInstant(sessionParticipantLogoutRequest)).to.exist;
-        expect(new Date(xmlhelper.getIssueInstant(sessionParticipantLogoutRequest)).getTime()).to.equal(frozenTime.getTime());
+        expect(xmlhelper.getIssueInstantUTC(sessionParticipantLogoutRequest)).to.equal(frozenTime);
         expect(xmlhelper.getDestination(sessionParticipantLogoutRequest)).to.equal(sessionParticipant2.serviceProviderLogoutURL);
         expect(xmlhelper.getConsent(sessionParticipantLogoutRequest)).to.equal('urn:oasis:names:tc:SAML:2.0:consent:unspecified');
         expect(xmlhelper.getElementText(sessionParticipantLogoutRequest, 'Issuer')).to.equal(samlIdPIssuer);
@@ -326,9 +325,8 @@ describe('samlp logout with Session Participants - Session Provider', function (
 
         it('should validate LogoutResponse to the Session Participant that initiated the logout', function () {
           expect(sessionParticipantLogoutResponse).to.exist;
-          expect(xmlhelper.getIssueInstant(sessionParticipantLogoutResponse)).to.exist;
-          expect(new Date(xmlhelper.getIssueInstant(sessionParticipantLogoutRequest)).getTime()).to.equal(frozenTime.getTime());
-          expect(xmlhelper.getDestination(sessionParticipantLogoutResponse)).to.equal(sessionParticipant1.serviceProviderLogoutURL); 
+          expect(xmlhelper.getIssueInstantUTC(sessionParticipantLogoutRequest)).to.equal(frozenTime);
+          expect(xmlhelper.getDestination(sessionParticipantLogoutResponse)).to.equal(sessionParticipant1.serviceProviderLogoutURL);
           expect(xmlhelper.getInResponseTo(sessionParticipantLogoutResponse)).to.equal('samlr-220c705e-c15e-11e6-98a4-ecf4bbce4318');
           expect(xmlhelper.getIssuer(sessionParticipantLogoutResponse)).to.equal(samlIdPIssuer);
         });
@@ -540,8 +538,7 @@ describe('samlp logout with Session Participants - Session Provider', function (
 
       it('should validate LogoutRequest to Session Participant', function () {
         expect(sessionParticipantLogoutRequest).to.exist;
-        expect(xmlhelper.getIssueInstant(sessionParticipantLogoutRequest)).to.exist;
-        expect(new Date(xmlhelper.getIssueInstant(sessionParticipantLogoutRequest)).getTime()).to.equal(frozenTime.getTime());
+        expect(xmlhelper.getIssueInstantUTC(sessionParticipantLogoutRequest)).to.equal(frozenTime);
         expect(xmlhelper.getDestination(sessionParticipantLogoutRequest)).to.equal(sessionParticipant1.serviceProviderLogoutURL);
         expect(xmlhelper.getConsent(sessionParticipantLogoutRequest)).to.equal('urn:oasis:names:tc:SAML:2.0:consent:unspecified');
         expect(xmlhelper.getElementText(sessionParticipantLogoutRequest, 'Issuer')).to.equal(samlIdPIssuer);
@@ -610,8 +607,7 @@ describe('samlp logout with Session Participants - Session Provider', function (
 
       it('should validate LogoutRequest to Session Participant', function () {
         expect(sessionParticipantLogoutRequest).to.exist;
-        expect(xmlhelper.getIssueInstant(sessionParticipantLogoutRequest)).to.exist;
-        expect(new Date(xmlhelper.getIssueInstant(sessionParticipantLogoutRequest)).getTime()).to.equal(frozenTime.getTime());
+        expect(xmlhelper.getIssueInstantUTC(sessionParticipantLogoutRequest)).to.equal(frozenTime);
         expect(xmlhelper.getDestination(sessionParticipantLogoutRequest)).to.equal(sessionParticipant1.serviceProviderLogoutURL);
         expect(xmlhelper.getConsent(sessionParticipantLogoutRequest)).to.equal('urn:oasis:names:tc:SAML:2.0:consent:unspecified');
         expect(xmlhelper.getElementText(sessionParticipantLogoutRequest, 'Issuer')).to.equal(samlIdPIssuer);
@@ -698,8 +694,7 @@ describe('samlp logout with Session Participants - Session Provider', function (
 
         it('should validate LogoutRequest to Session Participant 2', function () {
           expect(sessionParticipant2LogoutRequest).to.exist;
-          expect(xmlhelper.getIssueInstant(sessionParticipant2LogoutRequest)).to.exist;
-          expect(new Date(xmlhelper.getIssueInstant(sessionParticipantLogoutRequest)).getTime()).to.equal(frozenTime.getTime());
+          expect(xmlhelper.getIssueInstantUTC(sessionParticipant2LogoutRequest)).to.equal(frozenTime);
           expect(xmlhelper.getDestination(sessionParticipant2LogoutRequest)).to.equal(sessionParticipant2.serviceProviderLogoutURL);
           expect(xmlhelper.getConsent(sessionParticipant2LogoutRequest)).to.equal('urn:oasis:names:tc:SAML:2.0:consent:unspecified');
           expect(xmlhelper.getElementText(sessionParticipant2LogoutRequest, 'Issuer')).to.equal(samlIdPIssuer);
@@ -862,8 +857,7 @@ describe('samlp logout with Session Participants - Session Provider', function (
 
       it('should validate LogoutRequest to Session Participant', function () {
         expect(sessionParticipantLogoutRequest).to.exist;
-        expect(xmlhelper.getIssueInstant(sessionParticipantLogoutRequest)).to.exist;
-        expect(new Date(xmlhelper.getIssueInstant(sessionParticipantLogoutRequest)).getTime()).to.equal(frozenTime.getTime());
+        expect(xmlhelper.getIssueInstantUTC(sessionParticipantLogoutRequest)).to.equal(frozenTime);
         expect(xmlhelper.getDestination(sessionParticipantLogoutRequest)).to.equal(sessionParticipant2.serviceProviderLogoutURL);
         expect(xmlhelper.getConsent(sessionParticipantLogoutRequest)).to.equal('urn:oasis:names:tc:SAML:2.0:consent:unspecified');
         expect(xmlhelper.getElementText(sessionParticipantLogoutRequest, 'Issuer')).to.equal(samlIdPIssuer);
@@ -917,9 +911,8 @@ describe('samlp logout with Session Participants - Session Provider', function (
 
         it('should validate LogoutResponse to the Session Participant that initiated the logout', function () {
           expect(sessionParticipantLogoutResponse).to.exist;
-          expect(xmlhelper.getIssueInstant(sessionParticipantLogoutResponse)).to.exist;
-          expect(new Date(xmlhelper.getIssueInstant(sessionParticipantLogoutRequest)).getTime()).to.equal(frozenTime.getTime());
-          expect(xmlhelper.getDestination(sessionParticipantLogoutResponse)).to.equal(sessionParticipant1.serviceProviderLogoutURL); 
+          expect(xmlhelper.getIssueInstantUTC(sessionParticipantLogoutRequest)).to.equal(frozenTime);
+          expect(xmlhelper.getDestination(sessionParticipantLogoutResponse)).to.equal(sessionParticipant1.serviceProviderLogoutURL);
           expect(xmlhelper.getInResponseTo(sessionParticipantLogoutResponse)).to.equal('pfx6fe657e3-1a7f-893e-f690-f7fc5162ea11');
           expect(xmlhelper.getIssuer(sessionParticipantLogoutResponse)).to.equal(samlIdPIssuer);
         });

--- a/test/samlp.logout.session_store.tests.js
+++ b/test/samlp.logout.session_store.tests.js
@@ -325,7 +325,7 @@ describe('samlp logout with Session Participants - Session Provider', function (
 
         it('should validate LogoutResponse to the Session Participant that initiated the logout', function () {
           expect(sessionParticipantLogoutResponse).to.exist;
-          expect(xmlhelper.getIssueInstantUTC(sessionParticipantLogoutRequest)).to.equal(frozenTime);
+          expect(xmlhelper.getIssueInstantUTC(sessionParticipantLogoutResponse)).to.equal(frozenTime);
           expect(xmlhelper.getDestination(sessionParticipantLogoutResponse)).to.equal(sessionParticipant1.serviceProviderLogoutURL);
           expect(xmlhelper.getInResponseTo(sessionParticipantLogoutResponse)).to.equal('samlr-220c705e-c15e-11e6-98a4-ecf4bbce4318');
           expect(xmlhelper.getIssuer(sessionParticipantLogoutResponse)).to.equal(samlIdPIssuer);
@@ -911,7 +911,7 @@ describe('samlp logout with Session Participants - Session Provider', function (
 
         it('should validate LogoutResponse to the Session Participant that initiated the logout', function () {
           expect(sessionParticipantLogoutResponse).to.exist;
-          expect(xmlhelper.getIssueInstantUTC(sessionParticipantLogoutRequest)).to.equal(frozenTime);
+          expect(xmlhelper.getIssueInstantUTC(sessionParticipantLogoutResponse)).to.equal(frozenTime);
           expect(xmlhelper.getDestination(sessionParticipantLogoutResponse)).to.equal(sessionParticipant1.serviceProviderLogoutURL);
           expect(xmlhelper.getInResponseTo(sessionParticipantLogoutResponse)).to.equal('pfx6fe657e3-1a7f-893e-f690-f7fc5162ea11');
           expect(xmlhelper.getIssuer(sessionParticipantLogoutResponse)).to.equal(samlIdPIssuer);

--- a/test/utils.tests.js
+++ b/test/utils.tests.js
@@ -1,0 +1,14 @@
+const timekeeper = require('timekeeper');
+const expect = require('chai').expect;
+
+const utils = require('../lib/utils');
+
+describe('utils', function () {
+  describe('getRoundTripDateFormat', function () {
+    it('should pad the millis appropriately', function () {
+      timekeeper.withFreeze(0, () => {
+        expect(utils.generateInstant()).to.equal('1970-01-01T00:00:00.000Z');
+      });
+    });
+  });
+});

--- a/test/utils.tests.js
+++ b/test/utils.tests.js
@@ -4,7 +4,7 @@ const expect = require('chai').expect;
 const utils = require('../lib/utils');
 
 describe('utils', function () {
-  describe('getRoundTripDateFormat', function () {
+  describe('generateInstant', function () {
     it('should pad the millis appropriately', function () {
       timekeeper.withFreeze(0, () => {
         expect(utils.generateInstant()).to.equal('1970-01-01T00:00:00.000Z');

--- a/test/xmlhelper.js
+++ b/test/xmlhelper.js
@@ -88,6 +88,14 @@ exports.getIssueInstant = function(assertion) {
   return doc.documentElement.getAttribute('IssueInstant');
 };
 
+/**
+ * @param {String} assertion
+ * @return {number} the instant in milliseconds since the Epoch
+ */
+exports.getIssueInstantUTC = function(assertion) {
+  return new Date(exports.getIssueInstant(assertion)).getTime();
+};
+
 exports.getConditions = function(assertion) {
   var doc = new xmldom.DOMParser().parseFromString(assertion);
   return doc.documentElement.getElementsByTagName('saml:Conditions');


### PR DESCRIPTION
SAML SLO is not working with SAP since IssueInstant does not include milliseconds as it is required by SAP IdP.

This changes the date formatting to use millisecond precision everywhere.