### PR TITLE
feat: allow unsigned assertions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/*
 .DS_Store
 coverage/*
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Options
 | profileMapper       | mapper to map users to claims (see PassportProfileMapper)| PassportProfileMapper |
 | signatureAlgorithm  | signature algorithm, options: rsa-sha1, rsa-sha256 | ```'rsa-sha256'``` |
 | digestAlgorithm     | digest algorithm, options: sha1, sha256          | ```'sha256'``` |
+| signResponse        | whether to sign the SAML response                | false                                        |
+| signAssertion       | whether to sign the SAML assertion               | true                                         |
 | RelayState          | state of the auth process                        | ```req.query.RelayState || req.body.RelayState``` |
 | sessionIndex          | the index of a particular session between the principal identified by the subject and the authenticating authority                        | _SessionIndex is not included_ |
 | responseHandler       | custom response handler for SAML response f(SAMLResponse, options, req, res, next) | HTML response that POSTS to postUrl |

--- a/lib/samlp.js
+++ b/lib/samlp.js
@@ -75,7 +75,7 @@ function getSamlResponse(options, user, callback) {
     return callback(error);
   }
 
-  var signAssertion = typeof options.signAssertion !== 'undefined' ? !!options.signAssertion : !options.signResponse;
+  var signAssertion = typeof options.signAssertion !== 'boolean' || options.signAssertion;
   var createAssertion = signAssertion ? saml20.create : saml20.createUnsignedAssertion;
   createAssertion.call(saml20, {
     signatureAlgorithm: options.signatureAlgorithm,

--- a/lib/samlp.js
+++ b/lib/samlp.js
@@ -75,7 +75,9 @@ function getSamlResponse(options, user, callback) {
     return callback(error);
   }
 
-  saml20.create({
+  var signAssertion = typeof options.signAssertion !== 'undefined' ? !!options.signAssertion : !options.signResponse;
+  var createAssertion = signAssertion ? saml20.create : saml20.createUnsignedAssertion;
+  createAssertion.call(saml20, {
     signatureAlgorithm: options.signatureAlgorithm,
     digestAlgorithm: options.digestAlgorithm,
     cert: options.cert,

--- a/lib/samlp.js
+++ b/lib/samlp.js
@@ -17,7 +17,7 @@ function buildSamlResponse(options) {
     issuer: options.issuer,
     samlStatusCode: options.samlStatusCode,
     samlStatusMessage: options.samlStatusMessage,
-    assertion: options.signedAssertion || ''
+    assertion: options.samlAssertion || ''
   });
 
   if (options.signResponse) {
@@ -61,10 +61,21 @@ function nameIdentiferNotFoundErrorMessage(options) {
   return baseMessage + probes;
 }
 
-function getSamlResponse(options, user, callback) {
-  options.profileMapper = options.profileMapper || PassportProfileMapper;
-  options.signatureNamespacePrefix = typeof options.signatureNamespacePrefix === 'string' ? options.signatureNamespacePrefix : '';
+function makeSamlConfig(opts) {
+  return Object.assign(
+    {
+      profileMapper: PassportProfileMapper,
+    },
+    opts,
+    {
+      signAssertion: typeof opts.signAssertion !== 'boolean' || opts.signAssertion,
+      signatureNamespacePrefix: typeof opts.signatureNamespacePrefix === 'string' ? opts.signatureNamespacePrefix : ''
+    }
+  );
+}
 
+function getSamlResponse(samlConfig, user, callback) {
+  var options = makeSamlConfig(samlConfig);
   var profileMap = options.profileMapper(user);
   var claims = profileMap.getClaims(options);
   var ni = profileMap.getNameIdentifier(options);
@@ -75,8 +86,7 @@ function getSamlResponse(options, user, callback) {
     return callback(error);
   }
 
-  var signAssertion = typeof options.signAssertion !== 'boolean' || options.signAssertion;
-  var createAssertion = signAssertion ? saml20.create : saml20.createUnsignedAssertion;
+  var createAssertion = options.signAssertion ? saml20.create : saml20.createUnsignedAssertion;
   createAssertion.call(saml20, {
     signatureAlgorithm: options.signatureAlgorithm,
     digestAlgorithm: options.digestAlgorithm,
@@ -97,12 +107,14 @@ function getSamlResponse(options, user, callback) {
     typedAttributes: options.typedAttributes,
     includeAttributeNameFormat: options.includeAttributeNameFormat,
     signatureNamespacePrefix: options.signatureNamespacePrefix
-  }, function (err, signedAssertion) {
+  }, function (err, samlAssertion) {
     if (err) return callback(err);
 
-    options.signedAssertion = signedAssertion;
-    options.samlStatusCode = options.samlStatusCode || constants.STATUS.SUCCESS;
-    var SAMLResponse = buildSamlResponse(options);
+    var SAMLResponse = buildSamlResponse(Object.assign({}, options, {
+      samlAssertion: samlAssertion,
+      samlStatusCode: options.samlStatusCode || constants.STATUS.SUCCESS
+    }));
+
     callback(null, SAMLResponse);
   });
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "body-parser": "^1.15.2",
-    "chai": "~1.5.0",
+    "chai": "^4.2.0",
     "cheerio": "~0.10.7",
     "express": "^3.11.0",
     "express-session": "^1.14.2",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "ejs": "2.5.5",
     "flowstate": "^0.4.0",
     "querystring": "^0.2.0",
-    "saml": "^0.14",
+    "saml": "^0.15.0-rc.0",
     "xml-crypto": "^1.5.3",
     "xmldom": "auth0/xmldom#v0.1.19-auth0_1",
     "xpath": "0.0.5",

--- a/test/samlp.tests.js
+++ b/test/samlp.tests.js
@@ -677,11 +677,12 @@ describe('samlp', function () {
         server.options = { signatureNamespacePrefix: 'ds', signResponse: true }; // for backward compatibility
       });
 
-      it('should sign the response and not the assertion', function (done) {
+      it('should sign the response and the assertion', function (done) {
         doSAMLRequest(function (samlResponse) {
           var signatures = samlResponse.documentElement.getElementsByTagName('ds:Signature');
-          expect(signatures).to.have.lengthOf(1);
+          expect(signatures).to.have.lengthOf(2);
           expect(signatures[0].parentNode.nodeName).to.equal('samlp:Response');
+          expect(signatures[1].parentNode.nodeName).to.equal('saml:Assertion');
           done();
         });
       });


### PR DESCRIPTION
### Description

Allows unsigned assertions using the `options.signAssertion` config property. This is an optional property that defaults to true.

### Testing

Unit tests added for all relevant combinations.