### PR TITLE
fix: catch possible SAML response signing error

### DIFF
--- a/lib/samlp.js
+++ b/lib/samlp.js
@@ -110,12 +110,16 @@ function getSamlResponse(samlConfig, user, callback) {
   }, function (err, samlAssertion) {
     if (err) return callback(err);
 
-    var SAMLResponse = buildSamlResponse(Object.assign({}, options, {
-      samlAssertion: samlAssertion,
-      samlStatusCode: options.samlStatusCode || constants.STATUS.SUCCESS
-    }));
+    try {
+      var SAMLResponse = buildSamlResponse(Object.assign({}, options, {
+        samlAssertion: samlAssertion,
+        samlStatusCode: options.samlStatusCode || constants.STATUS.SUCCESS
+      }));
 
-    callback(null, SAMLResponse);
+      callback(null, SAMLResponse);
+    } catch (err) {
+      callback(err);
+    }
   });
 }
 

--- a/lib/samlp.js
+++ b/lib/samlp.js
@@ -110,16 +110,17 @@ function getSamlResponse(samlConfig, user, callback) {
   }, function (err, samlAssertion) {
     if (err) return callback(err);
 
+    var SAMLResponse;
     try {
-      var SAMLResponse = buildSamlResponse(Object.assign({}, options, {
+      SAMLResponse = buildSamlResponse(Object.assign({}, options, {
         samlAssertion: samlAssertion,
         samlStatusCode: options.samlStatusCode || constants.STATUS.SUCCESS
       }));
-
-      callback(null, SAMLResponse);
     } catch (err) {
-      callback(err);
+      return callback(err);
     }
+
+    callback(null, SAMLResponse);
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "body-parser": "^1.15.2",
     "chai": "^4.2.0",
     "cheerio": "~0.10.7",
+    "cheerio-select": "~0.0.3",
     "express": "^3.11.0",
     "express-session": "^1.14.2",
     "istanbul": "^0.4.5",

--- a/test/samlp.tests.js
+++ b/test/samlp.tests.js
@@ -729,6 +729,10 @@ describe('samlp', function () {
           server.options.key = 'invalid_signing_key';
         });
 
+        after(function () {
+          delete server.options.key;
+        });
+
         it('should return an error', function (done) {
           doRawSAMLRequest(function (response) {
             expect(response.statusCode).to.equal(400);

--- a/test/samlp.tests.js
+++ b/test/samlp.tests.js
@@ -687,7 +687,7 @@ describe('samlp', function () {
         it('should return an error', function (done) {
           doRawSAMLRequest(function (response) {
             expect(response.statusCode).to.equal(400);
-            expect(response.body).to.equal('error:0909006C:PEM routines:get_name:no start line');
+            expect(response.body).to.match(/error:\w+:PEM routines:\w+:no start line/);
             done();
           });
         });
@@ -736,7 +736,7 @@ describe('samlp', function () {
         it('should return an error', function (done) {
           doRawSAMLRequest(function (response) {
             expect(response.statusCode).to.equal(400);
-            expect(response.body).to.equal('error:0909006C:PEM routines:get_name:no start line');
+            expect(response.body).to.match(/error:\w+:PEM routines:\w+:no start line/);
             done();
           });
         });


### PR DESCRIPTION
### Description

This PR allows to catch an error that might happen due to invalid signing key (badly formatted) during SAML response signing.

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality
