### PR TITLE
chore!: Fix dependency security issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,3 @@ node_js:
   - 10.16.0
   - 12.10.0
   - 14.15.4
-before_install:
-  - npm i -g npm@5

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 sudo: false
 language: node_js
 node_js:
-  - 4.8.5
-  - 6.9.2
-  - 8.17.0
   - 10.16.0
   - 12.10.0
+  - 14.15.4
 before_install:
   - npm i -g npm@5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [5.0.0-rc.1](https://github.com/auth0/node-samlp/compare/v4.0.1...v5.0.0-rc.1) (2021-01-22)
+
+## [5.0.0-rc.0](https://github.com/auth0/node-samlp/compare/v4.0.0...v5.0.0-rc.0) (2021-01-22)
+
+
+### ⚠ BREAKING CHANGES
+
+* fix npm audit and library upgrades
+* remove ci for node v4, 6, 8, add 14
+
+* fix npm audit and library upgrades ([a2688c7](https://github.com/auth0/node-samlp/commit/a2688c702792fba90db4e7c72c463b223498c127))
+* remove ci for node v4, 6, 8, add 14 ([3019b74](https://github.com/auth0/node-samlp/commit/3019b747a0b46f571d4b6a1b3227dec56e7a71d8))
+
 ## [5.0.0-rc.0](https://github.com/auth0/node-samlp/compare/v4.0.0...v5.0.0-rc.0) (2021-01-22)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,18 +6,6 @@ All notable changes to this project will be documented in this file. See [standa
 
 ## [5.0.0-rc.0](https://github.com/auth0/node-samlp/compare/v4.0.0...v5.0.0-rc.0) (2021-01-22)
 
-
-### ⚠ BREAKING CHANGES
-
-* fix npm audit and library upgrades
-* remove ci for node v4, 6, 8, add 14
-
-* fix npm audit and library upgrades ([a2688c7](https://github.com/auth0/node-samlp/commit/a2688c702792fba90db4e7c72c463b223498c127))
-* remove ci for node v4, 6, 8, add 14 ([3019b74](https://github.com/auth0/node-samlp/commit/3019b747a0b46f571d4b6a1b3227dec56e7a71d8))
-
-## [5.0.0-rc.0](https://github.com/auth0/node-samlp/compare/v4.0.0...v5.0.0-rc.0) (2021-01-22)
-
-
 ### ⚠ BREAKING CHANGES
 
 * fix npm audit and library upgrades

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+## [5.0.0-rc.0](https://github.com/auth0/node-samlp/compare/v4.0.0...v5.0.0-rc.0) (2021-01-22)
+
+
+### ⚠ BREAKING CHANGES
+
+* fix npm audit and library upgrades
+* remove ci for node v4, 6, 8, add 14
+
+* fix npm audit and library upgrades ([a2688c7](https://github.com/auth0/node-samlp/commit/a2688c702792fba90db4e7c72c463b223498c127))
+* remove ci for node v4, 6, 8, add 14 ([3019b74](https://github.com/auth0/node-samlp/commit/3019b747a0b46f571d4b6a1b3227dec56e7a71d8))

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "flowstate": "^0.4.0",
     "querystring": "^0.2.0",
     "saml": "^1.0.0",
-    "standard-version": "^9.1.0",
     "xml-crypto": "^2.0.0",
     "xmldom": "auth0/xmldom#v0.1.19-auth0_1",
     "xpath": "0.0.5",
@@ -41,6 +40,7 @@
     "istanbul": "^0.4.5",
     "mocha": "~8.2.1",
     "request": "~2.88.0",
+    "standard-version": "^9.1.0",
     "timekeeper": "^2.2.0",
     "uid2": "0.0.3"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "samlp",
-  "version": "4.0.0",
+  "version": "5.0.0-rc.0",
   "description": "SAML Protocol server middleware",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "samlp",
-  "version": "4.0.1",
+  "version": "5.0.0-rc.1",
   "description": "SAML Protocol server middleware",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "./node_modules/.bin/_mocha -R spec",
     "cover": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha",
-    "open_cover": "open coverage/lcov-report/*.html"
+    "open_cover": "open coverage/lcov-report/*.html",
+    "release": "standard-version"
   },
   "repository": {
     "type": "git",
@@ -23,7 +24,8 @@
     "ejs": "2.5.5",
     "flowstate": "^0.4.0",
     "querystring": "^0.2.0",
-    "saml": "^0.15.0-rc.0",
+    "saml": "^1.0.0",
+    "standard-version": "^9.1.0",
     "xml-crypto": "^2.0.0",
     "xmldom": "auth0/xmldom#v0.1.19-auth0_1",
     "xpath": "0.0.5",
@@ -33,10 +35,10 @@
     "body-parser": "^1.15.2",
     "chai": "^4.2.0",
     "cheerio": "~0.10.7",
-    "express": "^3.11.0",
+    "cheerio-select": "~0.0.3",
+    "express": "^4.17.1",
     "express-session": "^1.14.2",
-    "istanbul": "^0.4.5",
-    "mocha": "~1.8.1",
+    "mocha": "~8.2.1",
     "request": "~2.88.0",
     "timekeeper": "^2.2.0",
     "uid2": "0.0.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "samlp",
-  "version": "5.0.0-rc.0",
+  "version": "5.0.0-rc.1",
   "description": "SAML Protocol server middleware",
   "main": "lib/index.js",
   "scripts": {

--- a/test/fixture/server.js
+++ b/test/fixture/server.js
@@ -40,15 +40,11 @@ module.exports.start = function(options, callback){
   var app = express();
   app.use(bodyParser.urlencoded({ extended: true }));
   app.use(express.json());
-
-  app.configure(function(){
-    this.use(function(req,res,next){
-      req.user = fakeUser;
-      next();
-    });
-
-    this.use(expressSession({secret:'somesecrettokenhere'}));
+  app.use(function(req,res,next){
+    req.user = fakeUser;
+    next();
   });
+  app.use(expressSession({secret:'somesecrettokenhere'}));
 
   function getPostURL (wtrealm, wreply, req, callback) {
     callback(null, 'http://office.google.com');


### PR DESCRIPTION
### Description

- Resolves all critical and high npm-audit issues by updating dependancies:
  - **xml-crypto** (1.5.3 -> 2.0.0) This version removes support for HMAC by default, which is unsupported by this library  - security fix
  - **saml** (0.15.0-rc.0 -> 1.0.0) Removes support for node <v10  - security fix
  - Dev dependancies: 
    - **express** (3.11.0 -> 4.17.1) Major release that changes API footprint - security fix, removes support for node <v10
    - **mocha** (1.8.1 -> 8.2.1) Major release that changes API footprint - security fix, removes support for node <v10
    - Locks cheerio-select version to fix test issues.
    - Small refactor of server.js to support newer express version.

**BREAKING CHANGE:** This removes support for node versions 4, 6 & 8 - newer versions of mocha use async/await, causing tests to fail in older versions.

### References

Addressing Issues:
https://github.com/auth0/node-samlp/issues/106
https://github.com/auth0/node-samlp/issues/107

Addressing issues resolved in other PRs:
https://github.com/auth0/node-samlp/pull/109

### Testing

No functional changes introduced

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
