### PR TITLE
Accept multiple SessionIndex elements in SP-initated LogoutRequests

### DIFF
--- a/lib/logout.js
+++ b/lib/logout.js
@@ -223,7 +223,7 @@ module.exports.logout = function (options) {
           if (err) { return next(err); }
           if (!state) { return next(new Error('Invalid RelayState')); }
 
-          options.sessionParticipants.get(state.issuer, state.sessionIndex, state.nameId, function (err, sessionParticipant) {
+          options.sessionParticipants.get(state.issuer, [state.sessionIndex], state.nameId, function (err, sessionParticipant) {
             if (err) { return next(err); }
             if (!sessionParticipant) { return next(new Error('Invalid Session Participant')) };
 

--- a/lib/logout.js
+++ b/lib/logout.js
@@ -154,9 +154,9 @@ module.exports.logout = function (options) {
     try {
       // SP Initated flow.
       if (req.query.SAMLRequest || req.body.SAMLRequest) {
-        var opts = {
-          getCredentials: function getCredentials(issuer, sessionIndex, nameId, cb) {
-            options.sessionParticipants.get(issuer, sessionIndex, nameId, function (err, session) {
+        const opts = {
+          getCredentials: function getCredentials(issuer, sessionIndices, nameId, cb) {
+            options.sessionParticipants.get(issuer, sessionIndices, nameId, function (err, session) {
               if (err) { return cb(err); }
               if (!session) { return cb(new Error('Invalid Session Participant')) };
               if (!session.cert) { return cb(); };
@@ -175,12 +175,12 @@ module.exports.logout = function (options) {
             return next(new Error('SAML Request with no issuer. Issuer is a mandatory element.'));
           }
 
-          options.sessionParticipants.get(requestData.issuer, requestData.sessionIndex, requestData.nameId, function (err, session) {
+          options.sessionParticipants.get(requestData.issuer, requestData.sessionIndices, requestData.nameId, function (err, session) {
             if (err) { return next(err); }
             if (!session && !options.destination) { return next(new Error('Invalid Session Participant')); }
 
             // We should store who requested the logout, so we can reply back with LogoutResponse
-            var spData = {
+            const spData = {
               parsedRequest: {
                 id: requestData.id,
                 serviceProviderLogoutURL: (session|| {}).serviceProviderLogoutURL || options.destination
@@ -195,7 +195,8 @@ module.exports.logout = function (options) {
               // This session is already saved in the store.
               // We should not send a LogoutRequest to that session
               // Only a LogoutResponse when there are no other session participants active
-              options.sessionParticipants.remove(requestData.issuer, requestData.sessionIndex, requestData.nameId, function (err) {
+              const { serviceProviderId, sessionIndex, nameId } = session || {};
+              options.sessionParticipants.remove(serviceProviderId, sessionIndex, nameId, function (err) {
                 if (err) { return next(err); }
                 
                 prepareAndSendLogoutRequest(options.sessionParticipants, transactionId, req, res, next);
@@ -265,30 +266,30 @@ module.exports.logout = function (options) {
  * @returns {Object} The Logout Request data as a JSON Object
  */
 function parseIncomingLogoutRequest(req, samlRequest, options, callback) {
-  var type = "LOGOUT_REQUEST";
+  const type = "LOGOUT_REQUEST";
   utils.parseSamlRequest(req, samlRequest, type, options, function (err, logoutRequestDom) {
     if (err) { return callback(err); }
 
-    var data = {};
-    var issuer = xpath.select(constants.ELEMENTS[type].ISSUER_PATH, logoutRequestDom);
+    const data = {};
+    const issuer = xpath.select(constants.ELEMENTS[type].ISSUER_PATH, logoutRequestDom);
     if (issuer && issuer.length > 0) { data.issuer = issuer[0].textContent; }
 
-    var sessionIndex = xpath.select("//*[local-name(.)='SessionIndex']/text()", logoutRequestDom);
-    if (sessionIndex && sessionIndex.length > 0) { data.sessionIndex = sessionIndex[0].textContent; }
+    const sessionIndexNodes = xpath.select("//*[local-name(.)='SessionIndex']/text()", logoutRequestDom);
+    if (sessionIndexNodes && sessionIndexNodes.length > 0) { data.sessionIndices = sessionIndexNodes.map((si) => si.textContent); }
 
-    var nameId = xpath.select("//*[local-name(.)='NameID']", logoutRequestDom);
+    const nameId = xpath.select("//*[local-name(.)='NameID']", logoutRequestDom);
     if (nameId && nameId.length > 0) {
       data.nameId = nameId[0].textContent;
       data.nameIdFormat = nameId[0].getAttribute('Format');
     }
 
-    var destination = logoutRequestDom.documentElement.getAttribute('Destination');
+    const destination = logoutRequestDom.documentElement.getAttribute('Destination');
     if (destination) { data.destination = destination; }
 
-    var id = logoutRequestDom.documentElement.getAttribute('ID');
+    const id = logoutRequestDom.documentElement.getAttribute('ID');
     if (id) data.id = id;
 
-    var signature = xpath.select(options.signaturePath || constants.ELEMENTS[type].SIGNATURE_VALIDATION_PATH, logoutRequestDom);
+    const signature = xpath.select(options.signaturePath || constants.ELEMENTS[type].SIGNATURE_VALIDATION_PATH, logoutRequestDom);
     if (signature && signature.length > 0) { data.signature = signature[0].textContent; }
 
     callback(null, data);

--- a/lib/sessionParticipants/index.js
+++ b/lib/sessionParticipants/index.js
@@ -9,8 +9,12 @@ function matchingIndex(issuer, sessionIndex, nameId){
       if (session.serviceProviderId !== issuer) { return false; }
     }
 
+    const hasMatchingSessionIndex = Array.isArray(sessionIndex)
+      ? sessionIndex.some((si) => si === session.sessionIndex)
+      : sessionIndex === session.sessionIndex;
+
     // SessionIndex and NameID should match
-    return session.sessionIndex === sessionIndex && session.nameId === nameId;
+    return hasMatchingSessionIndex && session.nameId === nameId;
   }
 }
 
@@ -20,16 +24,18 @@ function matchingIndex(issuer, sessionIndex, nameId){
  * used to find the correct Session Participant object which
  * represents the issuer of the previous mentions request/response.
  * 
- * @issuer {string}   The string as it was received in the SAML request/response
- * @sessionIndex {string}   The string as it was received in the SAML request/response. Only available in LogoutRequests
- * @cb     {function} The callback that will be called with '(err, sessionParticipant)'
+ * @issuer {string} The string as it was received in the SAML request/response
+ * @sessionIndices {string|string[]} An single string or array of strings representing the
+ * SessionIndex values as received in the SAML request/response. Only available in LogoutRequests.
+ * @nameId {string} The value of the nameId element from the SAML request/response
+ * @cb {function} The callback that will be called with '(err, sessionParticipant)'
  */
-SessionParticipants.prototype.get = function(issuer, sessionIndex, nameId, cb) {
+SessionParticipants.prototype.get = function(issuer, sessionIndices, nameId, cb) {
   // SessionIndex should be mandatory, but not issuer
   // Let's keep using issuer only if available
-  var s = this._participants.find(matchingIndex(issuer, sessionIndex, nameId));
+  const sessionParticipant = this._participants.find(matchingIndex(issuer, sessionIndices, nameId));
   
-  if (cb) { return cb(null, s); }
+  if (cb) { return cb(null, sessionParticipant); }
 };
 
 /**
@@ -59,19 +65,18 @@ SessionParticipants.prototype.getFirst = function(cb) {
 /**
  * Remove a Session Participant from the data structure.
  * 
- * @issuer {string}   The string as it was received in the SAML request/response
- * @sessionIndex {string}   The string as it was received in the SAML request/response. Only available in LogoutRequests 
- * @cb     {function} The callback that will be called with '(err, removedElement)'
+ * @serviceProviderId {string} The serviceProviderId value of the session participant
+ * @sessionIndex {string} The sessionIndex of the session participant
+ * @nameId {string} The nameId of the session participant
+ * @cb {function} The callback that will be called with '(err, removedElement)'
  */
-SessionParticipants.prototype.remove = function(issuer, sessionIndex, nameId, cb) {
-  var sessions = this._participants;
-  if (!sessions || sessions.length === 0 || !issuer) { return cb(); }
-  
-  // SessionIndex should be mandatory, but not issuer
-  // Let's keep using issuer only if available
-  var sessionIndexToRemove = sessions.findIndex(matchingIndex(issuer, sessionIndex, nameId));
+SessionParticipants.prototype.remove = function(serviceProviderId, sessionIndex, nameId, cb) {
+  const sessions = this._participants;
+  if (!sessions || sessions.length === 0 || !serviceProviderId) { return cb(); }
 
-  var removedElement;
+  const sessionIndexToRemove = sessions.findIndex(matchingIndex(serviceProviderId, sessionIndex, nameId));
+
+  let removedElement;
   // Remove the session from the array
   if (sessionIndexToRemove > -1) {
     removedElement = sessions.splice(sessionIndexToRemove, 1);

--- a/lib/sessionParticipants/index.js
+++ b/lib/sessionParticipants/index.js
@@ -25,8 +25,8 @@ function matchingIndex(issuer, sessionIndex, nameId){
  * represents the issuer of the previous mentions request/response.
  * 
  * @issuer {string} The string as it was received in the SAML request/response
- * @sessionIndices {string|string[]} An single string or array of strings representing the
- * SessionIndex values as received in the SAML request/response. Only available in LogoutRequests.
+ * @sessionIndices {string[]} An array of strings representing the SessionIndex
+ * values as received in the SAML request/response. Only available in LogoutRequests.
  * @nameId {string} The value of the nameId element from the SAML request/response
  * @cb {function} The callback that will be called with '(err, sessionParticipant)'
  */

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -44,8 +44,8 @@ module.exports.parseSamlRequest = function(req, samlRequest, type, options, call
       return cb(null, false);
     }
 
-    var issuer, sessionIndex, nameId;
-    var issuerNode = xpath.select(constants.ELEMENTS[type].ISSUER_PATH, xml);
+    let issuer, sessionIndices, nameId;
+    const issuerNode = xpath.select(constants.ELEMENTS[type].ISSUER_PATH, xml);
 
     if (issuerNode && issuerNode.length > 0) {
       issuer = issuerNode[0].textContent;
@@ -53,25 +53,25 @@ module.exports.parseSamlRequest = function(req, samlRequest, type, options, call
 
     // If LogoutRequest, we should check sessionIndex too
     if (constants.ELEMENTS[type].SESSION_INDEX_PATH){
-      var sessionIndexNode = xpath.select(constants.ELEMENTS[type].SESSION_INDEX_PATH, xml);
-      if (sessionIndexNode && sessionIndexNode.length > 0) {
-        sessionIndex = sessionIndexNode[0].textContent;
+      const sessionIndexNodes = xpath.select(constants.ELEMENTS[type].SESSION_INDEX_PATH, xml);
+      if (sessionIndexNodes && sessionIndexNodes.length > 0) {
+        sessionIndices = sessionIndexNodes.map((si) => si.textContent);
       }
     }
 
     // If LogoutRequest, we should check sessionIndex too
     if (constants.ELEMENTS[type].NAME_ID){
-      var nameIdNode = xpath.select(constants.ELEMENTS[type].NAME_ID, xml);
+      const nameIdNode = xpath.select(constants.ELEMENTS[type].NAME_ID, xml);
       if (nameIdNode && nameIdNode.length > 0) {
         nameId = nameIdNode[0].textContent;
       }
     }
 
-    if (!issuer && !sessionIndex && !nameId){
+    if (!issuer && !(sessionIndices && sessionIndices.length) && !nameId){
       return cb(null, false);
     }
 
-    options.getCredentials(issuer, sessionIndex, nameId, function (err, credentials) {
+    options.getCredentials(issuer, sessionIndices, nameId, function (err, credentials) {
       if (!credentials){
         return cb(null, false);
       }

--- a/test/samlp.logout.session_store.tests.js
+++ b/test/samlp.logout.session_store.tests.js
@@ -366,7 +366,7 @@ describe('samlp logout with Session Participants - Session Provider', function (
     });
 
     describe('SP initiated - LogoutRequest with multiple SessionIndex elements', function () {
-      var logoutResultValue, RelayState;
+      let logoutResultValue;
 
       before(function () {
         sessions.splice(0);
@@ -390,16 +390,15 @@ describe('samlp logout with Session Participants - Session Provider', function (
         }, function (err, response){
           if(err) return done(err);
           expect(response.statusCode).to.equal(302);
-          var qs = require('querystring');
-          var i = response.headers.location.indexOf('SAMLResponse=');
-          var query = qs.parse(response.headers.location.substr(i));
-          var SAMLResponse = query.SAMLResponse;
-          RelayState = query.RelayState;
+          const qs = require('querystring');
+          const i = response.headers.location.indexOf('SAMLResponse=');
+          const query = qs.parse(response.headers.location.substr(i));
+          const SAMLResponse = query.SAMLResponse;
           
-          zlib.inflateRaw(new Buffer(SAMLResponse, 'base64'), function (err, decodedAndInflated) {
+          zlib.inflateRaw(Buffer.from(SAMLResponse, 'base64'), function (err, decodedAndInflated) {
             if(err) return done(err);
             signedAssertion = /(<samlp:StatusCode.*\/>)/.exec(decodedAndInflated)[1];
-            var doc = new xmldom.DOMParser().parseFromString(signedAssertion);
+            const doc = new xmldom.DOMParser().parseFromString(signedAssertion);
             logoutResultValue = doc.documentElement.getAttribute('Value');
 
             done();

--- a/test/samlp.logout.session_store.tests.js
+++ b/test/samlp.logout.session_store.tests.js
@@ -365,6 +365,57 @@ describe('samlp logout with Session Participants - Session Provider', function (
       });
     });
 
+    describe('SP initiated - LogoutRequest with multiple SessionIndex elements', function () {
+      var logoutResultValue, RelayState;
+
+      before(function () {
+        sessions.splice(0);
+        sessions.push(sessionParticipant1);
+      });
+
+      // SAMLRequest: base64 encoded + deflated + URLEncoded
+      // Signature: URLEncoded
+      // SigAlg: URLEncoded
+
+      // <samlp:LogoutRequest xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="samlr-220c705e-c15e-11e6-98a4-ecf4bbce4318" IssueInstant="2016-12-13T18:01:12Z" Version="2.0">
+      //   <saml:Issuer>https://foobarsupport.zendesk.com</saml:Issuer>
+      //   <saml:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">foo@example.com</saml:NameID>
+      //   <samlp:SessionIndex>not-the-session-index</samlp:SessionIndex>
+      //   <samlp:SessionIndex>1</samlp:SessionIndex>
+      // </samlp:LogoutRequest>
+      before(function (done) {
+        request.get({
+          followRedirect: false,
+          uri: 'http://localhost:5050/logout?SAMLRequest=fZHNTsMwEIRfJfLdSTYtpazaiEoVUqTCARAHbq6zpRHxD15Hqnh63ORSocLFh9n5ZnblFSvTe9y5DzfEZ%2FoaiGN2Mr1lHCdrMQSLTnHHaJUhxqjxZfO4wyov0QcXnXa9uED%2BJxQzhdg5K7JmuxZnIMiqKvVteUNSQ3oAaCHvlmouSR%2Fm%2B72m%2BQyWyc88UGM5KhvXoiphIaGSMHuFJZaAUL2L7I0Cp%2FA0zktRr87xOHKhPsboGYvi4NxeBR68dyHm32Rb4s9cO7MqLu0T%2B5QOaLbZgwtGxb8vgxxGpWvlYbQiGdX1m7YNxCzq1HlPJ2V8TxdNU%2FjU5PElOdPqTdrnVFsXZTyS5EmU3VmdsF%2FOazRcdxZX%2Frr%2BAQ%3D%3D&SigAlg=http%3A%2F%2Fwww.w3.org%2F2001%2F04%2Fxmldsig-more%23rsa-sha256&Signature=39NSgctst5GtoKkCh4yKFPm4t8v0lhLdYpS14hlsi%2FLRbRDz8GFuDLlR6OILVZy%2BdY9RwQKtaF7lZfkF7EyJ5Ip4EELojxNA4dVcn6%2Bl%2B0fRXUHQppoBEACzKH%2BZJVW3OL5cmKEMvPyM5H81oslBvgkSbX3XTr%2FhPLtmLpRzmo2R%2Fp6Igqdc6Lfo0Hj3WmjkiKh%2F3C%2F0w1sRLAI5KdojEXHuoaS10QxBJq2dUwHpMONP4PnD1M5Gq1Jq%2F3PafXC7KBIretam86Lau96anMWWqT60j05eXtPAew66ZFGmeXgRqPcEGat6flcJaDHmVgWjqY7gJHPP6XTBadnng3vIdQ%3D%3D'
+        }, function (err, response){
+          if(err) return done(err);
+          expect(response.statusCode).to.equal(302);
+          var qs = require('querystring');
+          var i = response.headers.location.indexOf('SAMLResponse=');
+          var query = qs.parse(response.headers.location.substr(i));
+          var SAMLResponse = query.SAMLResponse;
+          RelayState = query.RelayState;
+          
+          zlib.inflateRaw(new Buffer(SAMLResponse, 'base64'), function (err, decodedAndInflated) {
+            if(err) return done(err);
+            signedAssertion = /(<samlp:StatusCode.*\/>)/.exec(decodedAndInflated)[1];
+            var doc = new xmldom.DOMParser().parseFromString(signedAssertion);
+            logoutResultValue = doc.documentElement.getAttribute('Value');
+
+            done();
+          });
+        });
+      });
+
+      it('should respond with a Success value', function () {
+        expect(logoutResultValue).to.equal('urn:oasis:names:tc:SAML:2.0:status:Success');
+      });
+
+      it('should remove session from sessions array', function () {
+        expect(sessions.length).to.equal(0);
+      });
+    });
+
     describe('SP initiated - Invalid signature', function () {
       var response;
 


### PR DESCRIPTION
### Description

Adds support for multiple `SessionIndex` elements in SP-initiated LogoutRequests in accordance with the specification:

> 3.7.3.2 Session Authority Rules
> 
> Terminate the principal's current session as specified by the <saml:BaseID>, <saml:NameID>,or <saml:EncryptedID> element, and any <SessionIndex> elements present in the logoutrequest message.

⚠️ This is a breaking change in the `SessionParticipants` API and requires a major version bump ⚠️ 

The changes introduced in this PR:
* All `SessionIndex` value in an SP-initiated logout request are extracted (previously only the first one)
* `SessionParticipants#get` can be called with either an array of session indices or a single session index (previously only a single session index string value)

### References

- http://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf

### Testing

- [X] This change adds test coverage for new/changed/fixed functionality
