### PR TITLE
fix!: remove vulnerable node-saml dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ SAML Protocol middleware to create SAMLP identity providers for node.js.
 
     npm install samlp
 
+### Supported Node Versions
+
+node >= 12
+
 ## Introduction
 
 This middleware is meant to generate a valid SAML Protocol identity provider endpoint that speaks saml.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "samlp",
   "version": "6.0.2",
+  "engines": {
+    "node": ">=12"
+  },
   "description": "SAML Protocol server middleware",
   "main": "lib/index.js",
   "scripts": {
@@ -25,7 +28,7 @@
     "ejs": "2.5.5",
     "flowstate": "^0.4.0",
     "querystring": "^0.2.0",
-    "saml": "^1.0.0",
+    "saml": "^2.0.1",
     "xml-crypto": "^2.0.0",
     "@auth0/xmldom": "0.1.21",
     "xpath": "0.0.5",


### PR DESCRIPTION
### Description

Updated saml to version 2.0.0

BREAKING CHANGE: Requires NodeJS >= 12


### References

https://github.com/auth0/node-saml/releases/tag/v2.0.0

### Testing

All existing tests pass

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
