### PR TITLE
Bump ejs to 3.1.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,13 +24,13 @@
   "license": "mit",
   "dependencies": {
     "@auth0/thumbprint": "0.0.6",
+    "@auth0/xmldom": "0.1.21",
     "auth0-id-generator": "^0.2.0",
-    "ejs": "2.5.5",
+    "ejs": "^3.1.8",
     "flowstate": "^0.4.0",
     "querystring": "^0.2.0",
     "saml": "^3.0.0",
     "xml-crypto": "^2.0.0",
-    "@auth0/xmldom": "0.1.21",
     "xpath": "0.0.5",
     "xtend": "^1.0.3"
   },


### PR DESCRIPTION
### Description

This PR bumps ejs version to 3.1.8 to avoid [CVE-2022-29078](https://nvd.nist.gov/vuln/detail/CVE-2022-29078) which affects any version < 3.1.6.

### Testing

I just run the unit tests of the package (`npm test`) and all tests passed.
Don't know if any other test is needed for this.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
