### PR TITLE
Fix: Update saml and ejs dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
   "dependencies": {
     "@auth0/thumbprint": "0.0.6",
     "auth0-id-generator": "^0.2.0",
-    "ejs": "2.5.5",
+    "ejs": "^3.1.8",
     "flowstate": "^0.4.0",
     "querystring": "^0.2.0",
-    "saml": "^3.0.0",
+    "saml": "^3.0.1",
     "xml-crypto": "^2.0.0",
     "@auth0/xmldom": "0.1.21",
     "xpath": "0.0.5",


### PR DESCRIPTION

### Description

1. Updating the `saml` dependency to address CVE-2021-43138 and CVE-2022-24785.
2. Updating the `ejs` dependency to address CVE-2022-29078

### References
https://nvd.nist.gov/vuln/detail/CVE-2021-43138
https://nvd.nist.gov/vuln/detail/CVE-2022-24785
https://nvd.nist.gov/vuln/detail/CVE-2022-29078

### Testing

Verfied with `npm run test` 

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
