### PR TITLE
Remove deprecated dependency querystring

### DIFF
--- a/lib/claims/PassportProfileMapper.js
+++ b/lib/claims/PassportProfileMapper.js
@@ -48,9 +48,7 @@ PassportProfileMapper.prototype.getClaims = function () {
 
   Object.keys(this._pu).filter(function (k) {
       return !~dontRemapAttributes.indexOf(k);
-    }).forEach(function (k) {
-      claims['http://schemas.passportjs.com/' + k] = this._pu[k];
-    }.bind(this));
+    }).forEach((k) => { claims['http://schemas.passportjs.com/' + k] = this._pu[k]});
 
   return claims;
 };

--- a/lib/logout.js
+++ b/lib/logout.js
@@ -7,7 +7,6 @@ var signers               = require('./signers');
 var SessionStore          = require('flowstate').SessionStore;
 var SessionParticipants   = require('./sessionParticipants');
 var zlib                  = require('zlib');
-var qs                    = require('querystring');
 var xtend                 = require('xtend');
 var constants             = require('./constants');
 
@@ -361,7 +360,7 @@ function prepareAndSendToken(req, res, element_type, token, options, cb) {
     }
 
     params.SigAlg = signers.getSigAlg(options);
-    params.Signature = signers.sign(options, qs.stringify(params));
+    params.Signature = signers.sign(options, (new URLSearchParams(params)).toString());
 
     send(params);
   });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,5 @@
 const zlib                  = require('zlib');
 const xmldom                = require('@auth0/xmldom');
-const qs                    = require('querystring');
 const xpath                 = require('xpath');
 const url                   = require('url');
 const xtend                 = require('xtend');
@@ -215,7 +214,7 @@ function validateSignature(req, element_type, xml, options) {
         throw new Error('Invalid signature algorithm. Supported algorithms are http://www.w3.org/2001/04/xmldsig-more#rsa-sha1 and http://www.w3.org/2001/04/xmldsig-more#rsa-sha256');
       }
 
-      const valid = signers.isValidContentAndSignature(qs.stringify(signedContent), req.query.Signature, {
+      const valid = signers.isValidContentAndSignature((new URLSearchParams(signedContent)).toString(), req.query.Signature, {
         signingCert: options.signingCert,
         signatureAlgorithm: req.query.SigAlg
       });

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "auth0-id-generator": "^0.2.0",
     "ejs": "^3.1.8",
     "flowstate": "^0.4.0",
-    "querystring": "^0.2.0",
     "saml": "^3.0.1",
     "xml-crypto": "^2.0.0",
     "@auth0/xmldom": "0.1.21",

--- a/test/samlp.logout.custom_store.tests.js
+++ b/test/samlp.logout.custom_store.tests.js
@@ -6,7 +6,6 @@ var xmldom        = require('@auth0/xmldom');
 var xmlhelper     = require('./xmlhelper');
 var zlib          = require('zlib');
 var utils         = require('../lib/utils');
-var qs            = require('querystring');
 var signers       = require('../lib/signers');
 var InMemoryStore = require('./in_memory_store');
 var SPs           = require('../lib/sessionParticipants');
@@ -166,9 +165,8 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
         }, function (err, response){
           if(err) return done(err);
           expect(response.statusCode).to.equal(302);
-          var qs = require('querystring');
           var i = response.headers.location.indexOf('SAMLResponse=');
-          var query = qs.parse(response.headers.location.substr(i));
+          var query = Object.fromEntries(new URLSearchParams(response.headers.location.substr(i)));
           var SAMLResponse = query.SAMLResponse;
           RelayState = query.RelayState;
 
@@ -231,7 +229,7 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
 
           var i = response.headers.location.indexOf('?');
           var completeQueryString = response.headers.location.substr(i+1);
-          var parsedQueryString = qs.parse(completeQueryString);
+          var parsedQueryString = Object.fromEntries(new URLSearchParams(completeQueryString));
 
           SAMLRequest = parsedQueryString.SAMLRequest;
           sessionParticipantLogoutRequestRelayState = parsedQueryString.RelayState;
@@ -306,7 +304,7 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
           };
 
           // We need to sign the reponse here
-          var signature = signers.sign({key: sp2_credentials.key, signatureAlgorithm: 'rsa-sha1' }, qs.stringify(params));
+          var signature = signers.sign({key: sp2_credentials.key, signatureAlgorithm: 'rsa-sha1' }, (new URLSearchParams(params)).toString());
           params.Signature = signature;
 
           request.get({
@@ -316,11 +314,10 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
           }, function (err, response) {
             if (err) { return done(err); }
             expect(response.statusCode).to.equal(302);
-            var qs = require('querystring');
 
             var i = response.headers.location.indexOf('?');
             var completeQueryString = response.headers.location.substr(i+1);
-            var parsedQueryString = qs.parse(completeQueryString);
+            var parsedQueryString = Object.fromEntries(new URLSearchParams(completeQueryString));
 
             SAMLResponse = parsedQueryString.SAMLResponse;
             sessionParticipantLogoutResponseRelayState = parsedQueryString.RelayState;
@@ -466,7 +463,7 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
 
           var i = response.headers.location.indexOf('?');
           var completeQueryString = response.headers.location.substr(i+1);
-          var parsedQueryString = qs.parse(completeQueryString);
+          var parsedQueryString = Object.fromEntries(new URLSearchParams(completeQueryString));
 
           SAMLRequest = parsedQueryString.SAMLRequest;
           sessionParticipantLogoutRequestRelayState = parsedQueryString.RelayState;
@@ -538,7 +535,7 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
 
           var i = response.headers.location.indexOf('?');
           var completeQueryString = response.headers.location.substr(i+1);
-          var parsedQueryString = qs.parse(completeQueryString);
+          var parsedQueryString = Object.fromEntries(new URLSearchParams(completeQueryString));
 
           SAMLRequest = parsedQueryString.SAMLRequest;
           sessionParticipantLogoutRequestRelayState = parsedQueryString.RelayState;
@@ -614,7 +611,7 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
           };
 
           // We need to sign the reponse here
-          var signature = signers.sign({key: sp1_credentials.key, signatureAlgorithm: 'rsa-sha1' }, qs.stringify(params));
+          var signature = signers.sign({key: sp1_credentials.key, signatureAlgorithm: 'rsa-sha1' }, (new URLSearchParams(params)).toString());
           params.Signature = signature;
 
           request.get({
@@ -628,7 +625,7 @@ describe('samlp logout with Session Participants - Custom Provider', function ()
 
             var i = response.headers.location.indexOf('?');
             var completeQueryString = response.headers.location.substr(i+1);
-            var parsedQueryString = qs.parse(completeQueryString);
+            var parsedQueryString = Object.fromEntries(new URLSearchParams(completeQueryString))
 
             SAMLRequest2 = parsedQueryString.SAMLRequest;
             sessionParticipant2LogoutRequestRelayState = parsedQueryString.RelayState;

--- a/test/samlp.logout.session_store.tests.js
+++ b/test/samlp.logout.session_store.tests.js
@@ -6,7 +6,6 @@ var xmldom        = require('@auth0/xmldom');
 var xmlhelper     = require('./xmlhelper');
 var zlib          = require('zlib');
 var utils         = require('../lib/utils');
-var qs            = require('querystring');
 var signers       = require('../lib/signers');
 var fs            = require('fs');
 var path          = require('path');
@@ -243,9 +242,8 @@ describe('samlp logout with Session Participants - Session Provider', function (
         }, function (err, response){
           if(err) return done(err);
           expect(response.statusCode).to.equal(302);
-          var qs = require('querystring');
           var i = response.headers.location.indexOf('SAMLResponse=');
-          var query = qs.parse(response.headers.location.substr(i));
+          var query = Object.fromEntries(new URLSearchParams(response.headers.location.substr(i)));
           var SAMLResponse = query.SAMLResponse;
           RelayState = query.RelayState;
 
@@ -306,7 +304,7 @@ describe('samlp logout with Session Participants - Session Provider', function (
 
           var i = response.headers.location.indexOf('?');
           var completeQueryString = response.headers.location.substr(i+1);
-          var parsedQueryString = qs.parse(completeQueryString);
+          var parsedQueryString = Object.fromEntries(new URLSearchParams(completeQueryString));
 
           SAMLRequest = parsedQueryString.SAMLRequest;
           sessionParticipantLogoutRequestRelayState = parsedQueryString.RelayState;
@@ -380,7 +378,7 @@ describe('samlp logout with Session Participants - Session Provider', function (
           };
 
           // We need to sign the reponse here
-          var signature = signers.sign({key: sp2_credentials.key, signatureAlgorithm: 'rsa-sha1' }, qs.stringify(params));
+          var signature = signers.sign({key: sp2_credentials.key, signatureAlgorithm: 'rsa-sha1' }, (new URLSearchParams(params)).toString());
           params.Signature = signature;
 
           request.get({
@@ -390,11 +388,10 @@ describe('samlp logout with Session Participants - Session Provider', function (
           }, function (err, response) {
             if (err) { return done(err); }
             expect(response.statusCode).to.equal(302);
-            var qs = require('querystring');
 
             var i = response.headers.location.indexOf('?');
             var completeQueryString = response.headers.location.substr(i+1);
-            var parsedQueryString = qs.parse(completeQueryString);
+            var parsedQueryString = Object.fromEntries(new URLSearchParams(completeQueryString));
 
             SAMLResponse = parsedQueryString.SAMLResponse;
             sessionParticipantLogoutResponseRelayState = parsedQueryString.RelayState;
@@ -476,9 +473,8 @@ describe('samlp logout with Session Participants - Session Provider', function (
         }, function (err, response){
           if(err) return done(err);
           expect(response.statusCode).to.equal(302);
-          const qs = require('querystring');
           const i = response.headers.location.indexOf('SAMLResponse=');
-          const query = qs.parse(response.headers.location.substr(i));
+          const query = Object.fromEntries(new URLSearchParams(response.headers.location.substr(i)));
           const SAMLResponse = query.SAMLResponse;
 
           zlib.inflateRaw(Buffer.from(SAMLResponse, 'base64'), function (err, decodedAndInflated) {
@@ -656,7 +652,7 @@ describe('samlp logout with Session Participants - Session Provider', function (
 
           var i = response.headers.location.indexOf('?');
           var completeQueryString = response.headers.location.substr(i+1);
-          var parsedQueryString = qs.parse(completeQueryString);
+          var parsedQueryString = Object.fromEntries(new URLSearchParams(completeQueryString));
 
           SAMLRequest = parsedQueryString.SAMLRequest;
           sessionParticipantLogoutRequestSigAlg = parsedQueryString.SigAlg;
@@ -725,7 +721,7 @@ describe('samlp logout with Session Participants - Session Provider', function (
 
           var i = response.headers.location.indexOf('?');
           var completeQueryString = response.headers.location.substr(i+1);
-          var parsedQueryString = qs.parse(completeQueryString);
+          var parsedQueryString = Object.fromEntries(new URLSearchParams(completeQueryString));
 
           SAMLRequest = parsedQueryString.SAMLRequest;
           sessionParticipantLogoutRequestRelayState = parsedQueryString.RelayState;
@@ -799,7 +795,7 @@ describe('samlp logout with Session Participants - Session Provider', function (
           };
 
           // We need to sign the reponse here
-          var signature = signers.sign({key: sp1_credentials.key, signatureAlgorithm: 'rsa-sha1' }, qs.stringify(params));
+          var signature = signers.sign({key: sp1_credentials.key, signatureAlgorithm: 'rsa-sha1' }, (new URLSearchParams(params)).toString());
           params.Signature = signature;
 
           request.get({
@@ -812,7 +808,7 @@ describe('samlp logout with Session Participants - Session Provider', function (
 
             var i = response.headers.location.indexOf('?');
             var completeQueryString = response.headers.location.substr(i+1);
-            var parsedQueryString = qs.parse(completeQueryString);
+            var parsedQueryString = Object.fromEntries(new URLSearchParams(completeQueryString));
 
             SAMLRequest2 = parsedQueryString.SAMLRequest;
             sessionParticipant2LogoutRequestRelayState = parsedQueryString.RelayState;


### PR DESCRIPTION
### Description

Per [issue 137](https://github.com/auth0/node-samlp/issues/137) the dependency [querystring](https://www.npmjs.com/package/querystring) is deprecated. The changes here remove that dependency.

### References

[issue 137](https://github.com/auth0/node-samlp/issues/137) 

### Testing

I created a Dockerfile with the node 12

    # specify the node base image with your desired version node:<version>
    FROM node:12

and changed it for node 16:

    # specify the node base image with your desired version node:<version>
    FROM node:12

Then I add a mount (with the `-v` parameter) to `/code`. I could then run `cd code && npm run cover` 

### Checklist


- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not the default branch
