### PR TITLE
fix PassportProfileMapper.prototype.getNameIdentifier won't return email

### DIFF
--- a/lib/claims/PassportProfileMapper.js
+++ b/lib/claims/PassportProfileMapper.js
@@ -66,7 +66,7 @@ PassportProfileMapper.prototype.getNameIdentifier = function () {
   return {
     nameIdentifier: claims[fm.nameIdentifier] ||
                     claims[fm.name] ||
-                    claims[fm.emailaddress]
+                    claims[fm.email]
   };
 
 };

--- a/test/passportprofilemapper.tests.js
+++ b/test/passportprofilemapper.tests.js
@@ -1,0 +1,62 @@
+var expect        = require('chai').expect;
+var PassportProfileMapper = require('../lib/claims/PassportProfileMapper')
+
+describe('PassportProfileMapper', function () {
+    it('PassportProfileMapper.prototype.getNameIdentifier returns id', function() {
+        var profileMapper = new PassportProfileMapper({
+            'id': 'e9f7ac44-3f9c-488c-88a2-5b4b437749a9', 
+            'emails': [],
+            'displayName': null,
+            'name': {
+                'familyName': null,
+                'givenName': null,
+            }
+        })
+        var output = profileMapper.getNameIdentifier()
+        expect(output.nameIdentifier).to.eql('e9f7ac44-3f9c-488c-88a2-5b4b437749a9')
+    })
+
+    it('PassportProfileMapper.prototype.getNameIdentifier returns name', function() {
+        var profileMapper = new PassportProfileMapper({
+            'id': null, 
+            'emails': [],
+            'displayName': 'Curious George',
+            'name': {
+                'familyName': null,
+                'givenName': null,
+            }
+        })
+        var output = profileMapper.getNameIdentifier()
+        expect(output.nameIdentifier).to.eql('Curious George')
+    })
+
+    it('PassportProfileMapper.prototype.getNameIdentifier returns emails', function() {
+        var profileMapper = new PassportProfileMapper({
+            'id': null, 
+            'emails': [{
+                'value': 'george@example.com'
+            }],
+            'displayName': null,
+            'name': {
+                'familyName': null,
+                'givenName': null,
+            }
+        })
+        var output = profileMapper.getNameIdentifier()
+        expect(output.nameIdentifier).to.eql('george@example.com')
+    })
+
+    it('PassportProfileMapper.prototype.getNameIdentifier returns undefined', function() {
+        var profileMapper = new PassportProfileMapper({
+            'id': null, 
+            'emails': [],
+            'displayName': null,
+            'name': {
+                'familyName': 'Curious George',
+                'givenName': 'George',
+            }
+        })
+        var output = profileMapper.getNameIdentifier()
+        expect(output.nameIdentifier).to.eql(undefined)
+    })
+})


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

> Describe the purpose of this PR along with any background information and the impacts of the proposed change. For the benefit of the community, please do not assume prior context.
>
> Provide details that support your chosen implementation, including: breaking changes, alternatives considered, changes to the API, etc.
>
> If the UI is being changed, please provide screenshots.

PassportProfileMapper.prototype.getNameIdentifier won't return email.
Because `fm.emailaddress` is not defined

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
